### PR TITLE
List addon in the game section

### DIFF
--- a/emuelec-addon.sh
+++ b/emuelec-addon.sh
@@ -798,7 +798,7 @@ read -d '' addon <<EOF
 		<import addon="xbmc.python" version="2.1.0"/>
 	</requires>
 	<extension point="xbmc.python.pluginsource" library="default.py">
-		<provides>executable</provides>
+		<provides>executable game</provides>
 	</extension>
 	<extension point="xbmc.addon.metadata">
 		<summary lang="en">EmuELEC addon. Provides binary, cores and basic settings to launch it</summary>


### PR DESCRIPTION
Dear shantigilbert,

First thank you for having made EmuELEC, I was looking for this kind of addon to complete my Kodi setup on my Odroid N2.

I made a quick change on the `emuelec-addon.sh` to generate an `addon.xml` file that allows the
addon to be listed in the game section in addition of executable section. I think this will be an appropriate location to find the addon through the Kodi interface.

Fred