### PR TITLE
fixed libneocd core's bios check

### DIFF
--- a/packages/sx05re/emuelec/config/emuelec/scripts/batocera/batocera-systems
+++ b/packages/sx05re/emuelec/config/emuelec/scripts/batocera/batocera-systems
@@ -134,8 +134,8 @@ systems = {
 	"neogeo":   { "name": "NeoGeo", "biosFiles":    [ { "md5": "", "file": "bios/neogeo.zip" } ] },
 	"neogeocd": { "name": "NeoGeo CD", "biosFiles": [ { "md5": "", "file": "bios/neogeo.zip" },
 													  { "md5": "", "file": "bios/neocdz.zip" },
-                                                      { "md5": "", "file": "bios/ng-lo.rom"  },
-                                                      { "md5": "", "file": "bios/neocd_z.rom"} ] },
+                                                      { "md5": "E255264D85D5765013B1B2FA8109DD53", "file": "bios/neocd/ng-lo.rom"  },
+                                                      { "md5": "F39572AF7584CB5B3F70AE8CC848ABA2", "file": "bios/neocd/neocd_z.rom"} ] },
 
 
     # Sony Computer Entertainment


### PR DESCRIPTION
libneocd_libretro was looking for two bios files (ng-lo.rom and neocd_z.rom) on ~/roms/bios/neocd, but the script was only checking on ~/roms/bios.