### PR TITLE
Quick Fix to Scummvm.start path find

### DIFF
--- a/packages/sx05re/emulators/scummvmsa/bin/scummvm.start
+++ b/packages/sx05re/emulators/scummvmsa/bin/scummvm.start
@@ -16,7 +16,7 @@ create_svm(){
     id=($line);
     [[ -f "${CONFIG_DIR}/games/$id.scummvm" ]] && rm "${CONFIG_DIR}/games/$id.scummvm"
     touch "${CONFIG_DIR}/games/$id.scummvm"
-    SVMPATH=$(cat ${CONFIG_DIR}/scummvm.ini | grep -A 4 "${id}" | grep path= | sed "s|path=||" | head -n 1)
+    SVMPATH=$(cat ${CONFIG_DIR}/scummvm.ini | sed -n "/\[$id\]/,/\[/p" | grep path= | sed "s|path=||")
     echo "-p \"${SVMPATH}\" ${id}" > "${CONFIG_DIR}/games/$id.scummvm"
     echo "${id} has been added with the path $SVMPATH to ${CONFIG_DIR}/games/$id.scummvm"
 	done 


### PR DESCRIPTION
scummvm does not stick to a regular pattern when generating the ini.. so some games have the path within the first four lines, but this can be different depending on system type or even media.
grep replaced with sed to capture everything after the bracketed title till it hits the next opening bracket for the next title, then pulls the path.