### PR TITLE
Update to PSPmini platform in es_systems.cfg

### DIFF
--- a/packages/sx05re/emuelec-emulationstation/config/es_systems.cfg
+++ b/packages/sx05re/emuelec-emulationstation/config/es_systems.cfg
@@ -764,7 +764,7 @@ All systems must be contained within the <systemList> tag.-->
 		<path>/storage/roms/pspminis</path>
 		<extension>.iso .ISO .cso .CSO .pbp .PBP</extension>
 		<command>/emuelec/scripts/emuelecRunEmu.sh %ROM% -P%SYSTEM% --controllers="%CONTROLLERSCONFIG%"</command>
-		<platform>pspminis</platform>
+		<platform>psp</platform>
 		<theme>pspminis</theme>
 	</system>
 </systemList>


### PR DESCRIPTION
change of platform name for 'pspminis' to 'psp'... this allows scraping for pspmini roms perfectly