### PR TITLE
batocera-wifi: Fix parsing of SSIDs with spaces.

### DIFF
--- a/packages/sx05re/emuelec/config/emuelec/scripts/batocera/batocera-wifi
+++ b/packages/sx05re/emuelec/config/emuelec/scripts/batocera/batocera-wifi
@@ -8,10 +8,16 @@ do_help() {
     echo "${1} list" >&2
 }
 
+remove_last_word() {
+    echo "${@:1:$#-1}"
+}
+
 do_list() {
-    connmanctl services |
-	grep -E "^... [^ ]* [ ]* wifi_.*$" |
-	sed -e s+"^... \([^ ]*\) [ ]* wifi_.*$"+"\1"+
+    connmanctl services | while read -r line ; do
+        if [[ $line == *'wifi_'* ]]; then
+            echo $(remove_last_word $line)
+        fi
+    done
 }
 
 do_scanlist() {


### PR DESCRIPTION
Instead of using regexp magic, this patch simply checks for an "wifi_"
string in the line, which is probably just needed when connmanctl
outputs error messages.

This patch only uses internal bash and does not rely on external
commands like `grep` and `sed`.

The SSID line is simply split and the last word, which is the connmanctl
identifier, is removed. So we end up with full SSID strings, even if
they contain spaces or other symbols the regexp did not predict.