### PR TITLE
packages/emuelec-emulationstation: Fix git remote.

### DIFF
--- a/packages/sx05re/emuelec-emulationstation/package.mk
+++ b/packages/sx05re/emuelec-emulationstation/package.mk
@@ -2,12 +2,12 @@
 # Copyright (C) 2019-present Shanti Gilbert (https://github.com/shantigilbert)
 
 PKG_NAME="emuelec-emulationstation"
-PKG_VERSION="bcf6f851efe425beeb01104af5fdd949d1aee1c6"
+PKG_VERSION="d1f47dafb669ceb4a4091952398aca77496344c2"
 PKG_GIT_CLONE_BRANCH="EmuELEC"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
-PKG_SITE="https://github.com/shantigilbert/emuelec-emulationstation"
+PKG_SITE="https://github.com/EmuELEC/emuelec-emulationstation"
 PKG_URL="$PKG_SITE.git"
 PKG_DEPENDS_TARGET="toolchain SDL2-git freetype curl freeimage vlc bash rapidjson ${OPENGLES} SDL2_mixer fping pyyaml"
 PKG_SECTION="emuelec"


### PR DESCRIPTION
The commit is not found on the current outdated remote and the build
exits with the following error:
```
There is no commit 'bcf6f851efe425beeb01104af5fdd949d1aee1c6' on branch 'EmuELEC' of package 'emuelec-emulationstation'! Aborting!
FAILURE: scripts/install emuelec-emulationstation has failed!
```
On Github shantigilbert/emuelec-emulationstation redirects to
EmuELEC/emuelec-emulationstation, so I suppose the latter is the correct
remote.

This patch updates the remote at the most current commit id.