### PR TITLE
batocera-wifi: Strip prefix from service line.

### DIFF
--- a/packages/sx05re/emuelec/config/emuelec/scripts/batocera/batocera-wifi
+++ b/packages/sx05re/emuelec/config/emuelec/scripts/batocera/batocera-wifi
@@ -13,9 +13,10 @@ remove_last_word() {
 }
 
 do_list() {
-    connmanctl services | while read -r line ; do
-        if [[ $line == *'wifi_'* ]]; then
-            echo $(remove_last_word $line)
+    connmanctl services | while read; do
+        if [[ $REPLY == *'wifi_'* ]]; then
+          WITHOUT_PREFIX=${REPLY:4}
+          echo $(remove_last_word $WITHOUT_PREFIX)
         fi
     done
 }


### PR DESCRIPTION
To avoid garbage characters like `*AO` in the parsed SSID, which occured
for me after I connected to the network, I now read the full line string
with spaces and strip the 4 characters that are reserved for status
information in connmanctl manually.

The bash `read` command will strip leading spaces automatically when a
variable name is used, so to gain the full line one needs to use the
build in REPLY return variable, as described here:
https://stackoverflow.com/a/37797456/1946875

With this patch SSIDs don't contain garbage even when connected.
Tested it on OGA.