### PR TITLE
Update es_systems.cfg

### DIFF
--- a/packages/sx05re/emuelec-emulationstation/config/es_systems.cfg
+++ b/packages/sx05re/emuelec-emulationstation/config/es_systems.cfg
@@ -323,7 +323,7 @@ All systems must be contained within the <systemList> tag.-->
 		<path>/storage/roms/tg16</path>
 		<extension>.pce .PCE .bin .BIN .zip .ZIP .7z .7Z</extension>
 		<command>/emuelec/scripts/emuelecRunEmu.sh %ROM% -P%SYSTEM% --controllers="%CONTROLLERSCONFIG%"</command>
-		<platform>tg16</platform>
+		<platform>pcengine</platform>
 		<theme>tg16</theme>
 	</system>
 	<system>
@@ -332,7 +332,7 @@ All systems must be contained within the <systemList> tag.-->
 		<path>/storage/roms/tg16cd</path>
 		<extension>.pce .PCE .cue .CUE .ccd .CCD .iso .ISO .img .IMG .bin .BIN .chd .CHD .zip .ZIP .7z .7Z</extension>
 		<command>/emuelec/scripts/emuelecRunEmu.sh %ROM% -P%SYSTEM% --controllers="%CONTROLLERSCONFIG%"</command>
-		<platform>tg16cd</platform>
+		<platform>pcenginecd</platform>
 		<theme>tg16cd</theme>
 	</system>
 	<system>


### PR DESCRIPTION
Change TurboGrafx16 and TurboGrafxCD platforms to PCEngine and PCEngineCD for proper scraping (neither scraper can identify the tg16 platforms). Theme and name remain as TurboGrafx.