### PR TITLE
Added aircrack-ng RTL8812AU module for OGA

### DIFF
--- a/projects/Rockchip/devices/OdroidGoAdvance/options
+++ b/projects/Rockchip/devices/OdroidGoAdvance/options
@@ -47,7 +47,7 @@
   # for a list of additional drivers see packages/linux-drivers
   # Space separated list is supported,
   # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
-  ADDITIONAL_DRIVERS="" #RTL8192CU RTL8192DU RTL8192EU RTL8188EU RTL8812AU RTL8821CU"
+  ADDITIONAL_DRIVERS="RTL8812AU" #RTL8192CU RTL8192DU RTL8192EU RTL8188EU RTL8812AU RTL8821CU"
   
   # driver addons to install:
   # for a list of additinoal drivers see packages/linux-driver-addons

--- a/projects/Rockchip/devices/OdroidGoAdvance/packages/RTL8812AU/package.mk
+++ b/projects/Rockchip/devices/OdroidGoAdvance/packages/RTL8812AU/package.mk
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="RTL8812AU"
+PKG_VERSION="e65fc452294b7a3f3cce27a1bb6fcccba1aaba5d"
+PKG_SHA256="9914efc9d5bee8916193fa6dfdb2000918b6c4cb5451a0fb8a6e16c41021852c"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/aircrack-ng/rtl8812au"
+PKG_URL="https://github.com/aircrack-ng/rtl8812au/archive/$PKG_VERSION.tar.gz"
+PKG_DEPENDS_TARGET="toolchain linux"
+PKG_NEED_UNPACK="$LINUX_DEPENDS"
+PKG_LONGDESC="Realtek RTL8812AU Linux 3.x driver"
+PKG_IS_KERNEL_PKG="yes"
+
+pre_make_target() {
+  unset LDFLAGS
+}
+
+make_target() {
+  make V=1 \
+       ARCH=$TARGET_KERNEL_ARCH \
+       KSRC=$(kernel_path) \
+       CROSS_COMPILE=$TARGET_KERNEL_PREFIX \
+       CONFIG_POWER_SAVING=n
+}
+
+makeinstall_target() {
+  mkdir -p $INSTALL/$(get_full_module_dir)/$PKG_NAME
+    cp *.ko $INSTALL/$(get_full_module_dir)/$PKG_NAME
+}


### PR DESCRIPTION
Use the aircrack-ng implementation for RTL8812AU module. Compiles and works (tested with a TP Link Archer Nano)