### PR TITLE
Add sanity checks when launching Cave Story

### DIFF
--- a/packages/sx05re/emuelec/config/emuelec/ports/Cave Story.sh
+++ b/packages/sx05re/emuelec/config/emuelec/ports/Cave Story.sh
@@ -1,3 +1,13 @@
 #!/bin/bash
 
+if [[ ! -f /storage/roms/ports/CaveStory/Doukutsu.exe ]]; then
+    /emuelec/scripts/fbterm.sh "echo Could not find Doukutsu.exe, please make sure you copied the game into /storage/roms/ports/CaveStory.; sleep 10"
+    exit 1
+fi
+
+if [[ ! -d /storage/roms/ports/CaveStory/data ]]; then
+    /emuelec/scripts/fbterm.sh "echo Could not find the data directory, please make sure you copied the game data into /storage/roms/ports/CaveStory/data.; sleep 10"
+    exit 1
+fi
+
 /emuelec/scripts/emuelecRunEmu.sh "/storage/roms/ports/CaveStory/Doukutsu.exe" -Pports "${2}" -Cnxengine "-SC${0}"

--- a/packages/sx05re/emuelec/config/emuelec/ports/Cave Story.sh
+++ b/packages/sx05re/emuelec/config/emuelec/ports/Cave Story.sh
@@ -1,13 +1,7 @@
 #!/bin/bash
 
-if [[ ! -f /storage/roms/ports/CaveStory/Doukutsu.exe ]]; then
-    /emuelec/scripts/fbterm.sh "echo Could not find Doukutsu.exe, please make sure you copied the game into /storage/roms/ports/CaveStory.; sleep 10"
-    exit 1
-fi
-
-if [[ ! -d /storage/roms/ports/CaveStory/data ]]; then
-    /emuelec/scripts/fbterm.sh "echo Could not find the data directory, please make sure you copied the game data into /storage/roms/ports/CaveStory/data.; sleep 10"
-    exit 1
+if [[ ! -f /storage/roms/ports/CaveStory/Doukutsu.exe ]] || [[ ! -d /storage/roms/ports/CaveStory/data ]]; then
+    /emuelec/scripts/fbterm.sh "echo Could not find Doukutsu.exe or the data directory, please make sure you copied the game into /storage/roms/ports/CaveStory.; sleep 10"
 fi
 
 /emuelec/scripts/emuelecRunEmu.sh "/storage/roms/ports/CaveStory/Doukutsu.exe" -Pports "${2}" -Cnxengine "-SC${0}"

--- a/packages/sx05re/emuelec/config/emuelec/ports/Cave Story.sh
+++ b/packages/sx05re/emuelec/config/emuelec/ports/Cave Story.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 
 if [[ ! -f /storage/roms/ports/CaveStory/Doukutsu.exe ]] || [[ ! -d /storage/roms/ports/CaveStory/data ]]; then
-    /emuelec/scripts/fbterm.sh "echo Could not find Doukutsu.exe or the data directory, please make sure you copied the game into /storage/roms/ports/CaveStory.; sleep 10"
+    /emuelec/scripts/fbterm.sh "echo Could not find Doukutsu.exe or the data directory, please make sure you copied the game into /storage/roms/ports/CaveStory.; sleep 10" &
+    error_process="$!"
+    sleep 10
+    # Kill fbterm and all children
+    pkill -P "$!"
+    exit 1
 fi
 
 /emuelec/scripts/emuelecRunEmu.sh "/storage/roms/ports/CaveStory/Doukutsu.exe" -Pports "${2}" -Cnxengine "-SC${0}"

--- a/packages/sx05re/emuelec/config/emuelec/scripts/fbterm.sh
+++ b/packages/sx05re/emuelec/config/emuelec/scripts/fbterm.sh
@@ -24,6 +24,9 @@ if [ "$EE_DEVICE" == "OdroidGoAdvance" ]; then
 		"mplayer_video")
 			/storage/.config/emuelec/scripts/playvideo.sh "${2}" "${3}"
 		;;
+		*)
+			kmscon --font-size 8 --login /usr/bin/bash -- -c "${1}"
+		;;
 		esac
 	fi 
 else
@@ -34,8 +37,11 @@ else
 		*.sh)
 			fbterm "${1}" -s 24 < /dev/tty1
 		;;
-		*)
+		"mplayer_video")
 			fbterm /emuelec/scripts/playvideo.sh "${2}" "${3}" < /dev/tty1
+		;;
+		*)
+			fbterm -c "${1}" -s 24 < /dev/tty1
 		;;
 		esac
 	fi 


### PR DESCRIPTION
I extended fbterm.sh to allow it to run arbitrary commands and used this to run an echo command if some files are missing for Cave Story, to help the user understand they need to install the game manually.

This could easily be extended to other scripts too.

I sadly couldn't get dialog to work, so it's not as pretty as the dialogs from the file manager, but it's something at least.

Only tested on the Odroid Go Advance.

![IMG_20200707_192155](https://user-images.githubusercontent.com/1885159/86820059-d5023b80-c088-11ea-9462-02add54f6fc5.jpg)
