### PR TITLE
Fix error message showing on non-OGA devices

### DIFF
--- a/packages/sx05re/emuelec/config/emuelec/scripts/fbterm.sh
+++ b/packages/sx05re/emuelec/config/emuelec/scripts/fbterm.sh
@@ -41,7 +41,7 @@ else
 			fbterm /emuelec/scripts/playvideo.sh "${2}" "${3}" < /dev/tty1
 		;;
 		*)
-			fbterm -c "${1}" -s 24 < /dev/tty1
+			fbterm /usr/bin/bash -c "${1}" -s 24 < /dev/tty1
 		;;
 		esac
 	fi 


### PR DESCRIPTION
I forgot to tell fbterm it should run this in bash.

Please test this (as I don't have any device except the OGA) but I expect it should work.