### PR TITLE
Add --strictfilter

### DIFF
--- a/packages/sx05re/emuelec/config/emuelec/scripts/batocera/batocera-systems
+++ b/packages/sx05re/emuelec/config/emuelec/scripts/batocera/batocera-systems
@@ -264,13 +264,17 @@ if __name__ == '__main__':
             exit(2)
     elif sys.argv[1] == "--createReadme":
         createReadme(systems)
-    elif len(sys.argv) == 3 and sys.argv[1] == "--filter":
+    elif len(sys.argv) == 3 and sys.argv[1] in ["--filter", "--strictfilter"]:
         prefix = "/storage/roms/"
         lowered_name = sys.argv[2].lower()
 
         filtered_systems = {}
         for system in systems:
-            if lowered_name in system.lower() or lowered_name in systems[system]['name'].lower():
+            lowered_system = system.lower()
+            lowered_system_name = systems[system]['name'].lower()
+            
+            if ((lowered_name == lowered_system or lowered_name == lowered_system_name) or
+               (sys.argv[1] == "--filter" and (lowered_name in lowered_system or lowered_name in lowered_system_name))):
                 filtered_systems[system] = systems[system]
 
         if len(filtered_systems) == 0:


### PR DESCRIPTION
So you can filter for gb without also getting gbc and gba

```
$ ./packages/sx05re/emuelec/config/emuelec/scripts/batocera/batocera-systems --filter gb
> Game Boy
MISSING 32fbbd84168d3482956eb3c5051637f5 bios/gb_bios.bin
MISSING dbfce9db9deaa2567f6a84fde55f9680 bios/gbc_bios.bin
> Game Boy Advance
MISSING a860e8c0b6d573d191e4ec7db1b1e4f6 bios/gba_bios.bin
MISSING 32fbbd84168d3482956eb3c5051637f5 bios/gb_bios.bin
MISSING dbfce9db9deaa2567f6a84fde55f9680 bios/gbc_bios.bin
MISSING d574d4f9c12f305074798f54c091a8b4 bios/sgb_bios.bin
> Game Boy Color
MISSING 32fbbd84168d3482956eb3c5051637f5 bios/gb_bios.bin
MISSING dbfce9db9deaa2567f6a84fde55f9680 bios/gbc_bios.bin
```

```
$ ./packages/sx05re/emuelec/config/emuelec/scripts/batocera/batocera-systems --strictfilter gb
> Game Boy
MISSING 32fbbd84168d3482956eb3c5051637f5 bios/gb_bios.bin
MISSING dbfce9db9deaa2567f6a84fde55f9680 bios/gbc_bios.bin
```