### PR TITLE
Try to start game with missing BIOS anyway

### DIFF
--- a/packages/sx05re/emuelec/profile.d/99-emuelec.conf
+++ b/packages/sx05re/emuelec/profile.d/99-emuelec.conf
@@ -134,6 +134,11 @@ EMULATOR="${3}"
 ROMNAME="${4}"
 LOG="${5}"
 
+if [[ -z "$LOG" ]]; then
+	LOG="/emuelec/logs/emuelec.log"
+	cat /etc/motd > "$LOG"
+fi
+
 MISSINGBIOS="$(batocera-systems --strictfilter ${PLATFORM})"
 if [ "$?" == "2" ]; then
 
@@ -145,8 +150,8 @@ PLATFORMNAME=$(echo $PLATFORMNAME | sed -e 's/\\n//g')
 if [[ -f "${LOG}" ]]; then
 echo "${CORE} ${EMULATOR} ${ROMNAME}" >> $LOG
 echo "${PLATFORMNAME} missing BIOS - Could not find all BIOS: " >> $LOG
-echo "${MISSINGBIOS}" >> $EMUELECLOG
 echo "please make sure you copied the files into the corresponding folder " >> $LOG
+echo "${MISSINGBIOS}" >> $LOG
 fi
 	MISSINGBIOS=$(echo "$MISSINGBIOS" | sed -e 's/$/\\n/g')
     

--- a/packages/sx05re/emuelec/profile.d/99-emuelec.conf
+++ b/packages/sx05re/emuelec/profile.d/99-emuelec.conf
@@ -144,21 +144,20 @@ PLATFORMNAME=$(echo $PLATFORMNAME | sed -e 's/\\n//g')
 
 if [[ -f "${LOG}" ]]; then
 echo "${CORE} ${EMULATOR} ${ROMNAME}" >> $LOG
-echo "${PLATFORMNAME} missing BIOS - Could not find the needed BIOS: " >> $LOG
+echo "${PLATFORMNAME} missing BIOS - Could not find all BIOS: " >> $LOG
 echo "${MISSINGBIOS}" >> $EMUELECLOG
 echo "please make sure you copied the files into the corresponding folder " >> $LOG
 fi
 	MISSINGBIOS=$(echo "$MISSINGBIOS" | sed -e 's/$/\\n/g')
     
     if [[ "$EE_DEVICE" == "OdroidGoAdvance" ]]; then
-		/emuelec/scripts/fbterm.sh error "${PLATFORMNAME} missing BIOS" "Could not find the needed BIOS/files in /storage/roms: \n\n ${MISSINGBIOS} \n\nPlease make sure you copied the files into the corresponding folder \n\n this message will close in 10 seconds" &
+		/emuelec/scripts/fbterm.sh error "${PLATFORMNAME} missing BIOS" "Could not find all BIOS/files in /storage/roms, the game may not work: \n\n ${MISSINGBIOS} \n\nPlease make sure you copied the files into the corresponding folder \n\nThis message will close in 10 seconds" &
 		error_process="$!"
 		sleep 10
 		pkill -P $error_process
     else
-		/emuelec/scripts/fbterm.sh error "${PLATFORMNAME} missing BIOS" "Could not find the needed BIOS/files in /storage/roms: \n\n ${MISSINGBIOS} \n\nPlease make sure you copied the files into the corresponding folder "
+		/emuelec/scripts/fbterm.sh error "${PLATFORMNAME} missing BIOS" "Could not find all BIOS/files in /storage/roms, the game may not work: \n\n ${MISSINGBIOS} \n\nPlease make sure you copied the files into the corresponding folder"
     fi
-   exit 1
 fi
 }
 


### PR DESCRIPTION
I haven't tested this, as I haven't set up a dev environment yet and didn't manage to remount / rw, so couldn't replace it on my device. But this should fix https://github.com/EmuELEC/EmuELEC/issues/237 at least partially by trying to start the game anyway.

We probably need to just remove prboom.wad as a required file from batocera-systems in our case as we directly call doom1.wad, but this at least prevents completely breaking games if a BIOS file ends up being optional which I think is important