### PR TITLE
Gambatte Automatic Colorization

### DIFF
--- a/packages/sx05re/emuelec/config/emuelec/scripts/setsettings.sh
+++ b/packages/sx05re/emuelec/config/emuelec/scripts/setsettings.sh
@@ -441,6 +441,11 @@ sed -i "/gambatte_gb_internal_palette =/d" ${GAMBATTECONF}
 			echo "gambatte_gb_internal_palette = \"\"" >> ${RACORECONF}
 			echo "gambatte_gb_colorization = \"disabled\"" >> ${GAMBATTECONF}
 			echo "gambatte_gb_internal_palette = \"\"" >> ${GAMBATTECONF}
+		elif [ "${EES}" == "Best Guess" ]; then
+			echo "gambatte_gb_colorization = \"auto\"" >> ${RACORECONF}
+			echo "gambatte_gb_internal_palette = \"\"" >> ${RACORECONF}
+			echo "gambatte_gb_colorization = \"auto\"" >> ${GAMBATTECONF}
+			echo "gambatte_gb_internal_palette = \"\"" >> ${GAMBATTECONF}
 		else
 			echo "gambatte_gb_colorization = \"internal\"" >> ${RACORECONF}
 			echo "gambatte_gb_internal_palette = \"${EES}\"" >> ${RACORECONF}


### PR DESCRIPTION
This sets Gambatte's colorization mode to "auto" using the new "Best Guess" option from the updated emuelec-emulationstation list of colorization options.