### PR TITLE
Add .gb to supported extensions for GBC

### DIFF
--- a/packages/sx05re/emuelec-emulationstation/config/es_systems.cfg
+++ b/packages/sx05re/emuelec-emulationstation/config/es_systems.cfg
@@ -1000,7 +1000,7 @@ All systems must be contained within the <systemList> tag.-->
 		<release>1998</release>
 		<hardware>portable</hardware>		
 		<path>/storage/roms/gbc</path>
-		<extension>.gbc .GBC .zip .ZIP .7z .7Z</extension>
+		<extension>.gb .GB .gbc .GBC .zip .ZIP .7z .7Z</extension>
 		<command>/emuelec/scripts/emuelecRunEmu.sh %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers="%CONTROLLERSCONFIG%"</command>
 		<platform>gbc</platform>
 		<theme>gbc</theme>
@@ -1024,7 +1024,7 @@ All systems must be contained within the <systemList> tag.-->
 		<release>1998</release>
 		<hardware>portable</hardware>			
 		<path>/storage/roms/gbch</path>
-		<extension>.gbc .GBC .zip .ZIP .7z .7Z</extension>
+		<extension>.gb .GB .gbc .GBC .zip .ZIP .7z .7Z</extension>
 		<command>/emuelec/scripts/emuelecRunEmu.sh %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers="%CONTROLLERSCONFIG%"</command>
 		<platform>gbc</platform>
 		<theme>gbch</theme>

--- a/packages/sx05re/emulationstation-addon/config/es_systems.cfg
+++ b/packages/sx05re/emulationstation-addon/config/es_systems.cfg
@@ -411,7 +411,7 @@ All systems must be contained within the <systemList> tag.-->
 		<name>gbc</name>
 		<fullname>Nintendo Game Boy Color</fullname>
 		<path>/storage/roms/gbc</path>
-		<extension>.gbc .GBC .zip .ZIP .7z .7Z</extension>
+		<extension>.gb .GB .gbc .GBC .zip .ZIP .7z .7Z</extension>
 		<command>/emuelec/scripts/emuelecRunEmu.sh GBC %ROM% -PGBC</command>
 		<platform>gbc</platform>
 		<theme>gbc</theme>


### PR DESCRIPTION
The Retrode 2 dumps GBC games with the .gb extension and games like Tobu
Tobu Girl Deluxe are delivered as a .gb file too. The extension makes no
difference, so we also allow .gb extensions