### PR TITLE
Don't show .bin files for PSX

### DIFF
--- a/packages/sx05re/emuelec-emulationstation/config/es_systems.cfg
+++ b/packages/sx05re/emuelec-emulationstation/config/es_systems.cfg
@@ -1757,7 +1757,7 @@ All systems must be contained within the <systemList> tag.-->
 		<release>1994</release>
 		<hardware>console</hardware>		
 		<path>/storage/roms/psx</path>
-		<extension>.bin .BIN .cue .CUE .img .IMG .mdf .MDF .pbp .PBP .toc .TOC .cbn .CBN .m3u .M3U .ccd .CCD .chd .CHD .zip .ZIP .7z .7Z .iso .ISO</extension>
+		<extension>.cue .CUE .img .IMG .mdf .MDF .pbp .PBP .toc .TOC .cbn .CBN .m3u .M3U .ccd .CCD .chd .CHD .zip .ZIP .7z .7Z .iso .ISO</extension>
 		<command>/emuelec/scripts/emuelecRunEmu.sh %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers="%CONTROLLERSCONFIG%"</command>
 		<platform>psx</platform>
 		<theme>psx</theme>

--- a/packages/sx05re/emulationstation-addon/config/es_systems.cfg
+++ b/packages/sx05re/emulationstation-addon/config/es_systems.cfg
@@ -717,7 +717,7 @@ All systems must be contained within the <systemList> tag.-->
 		<name>psx</name>
 		<fullname>Sony Playstation</fullname>
 		<path>/storage/roms/psx</path>
-		<extension>.bin .BIN .cue .CUE .img .IMG .mdf .MDF .pbp .PBP .toc .TOC .cbn .CBN .m3u .M3U .ccd .CCD .chd .CHD .zip .ZIP .7z .7Z .iso .ISO</extension>
+		<extension>.cue .CUE .img .IMG .mdf .MDF .pbp .PBP .toc .TOC .cbn .CBN .m3u .M3U .ccd .CCD .chd .CHD .zip .ZIP .7z .7Z .iso .ISO</extension>
 		<command>/emuelec/scripts/emuelecRunEmu.sh LIBRETRO pcsx_rearmed %ROM% -PPSX</command>
 		<platform>psx</platform>
 		<theme>psx</theme>


### PR DESCRIPTION
PS1 games may contain several .bin files and running the .bin file is not recommended anyway. Hiding .bin will make it so that users won't see duplicate entries for their games.

Context: https://discordapp.com/channels/570131631260696576/670714772882325519/747982960178757664