### PR TITLE
Add argument for tty device

### DIFF
--- a/packages/sx05re/emuelec/config/emuelec/bin/joy2key.py
+++ b/packages/sx05re/emuelec/config/emuelec/bin/joy2key.py
@@ -256,10 +256,12 @@ for arg in args:
 event_format = 'IhBB'
 event_size = struct.calcsize(event_format)
 
+tty_device = sys.argv[2] if len(sys.argv) >= 3 else '/dev/tty'
+
 try:
-    tty_fd = open('/dev/tty', 'a')
+    tty_fd = open(tty_device, 'a')
 except IOError:
-    print 'Unable to open /dev/tty'
+    print 'Unable to open {}'.format(tty_device)
     sys.exit(1)
 
 rescan_time = time.time()


### PR DESCRIPTION
Assuming we can keep the first argument settings `/dev/input/jsX` in-place.