### PR TITLE
Fix killall triggering crash detection

### DIFF
--- a/packages/sx05re/emuelec/config/emuelec/scripts/fbterm.sh
+++ b/packages/sx05re/emuelec/config/emuelec/scripts/fbterm.sh
@@ -60,4 +60,4 @@ else
 fi
 
 joy2keyStop
-killall joy2key.py
+killall joy2key.py || true


### PR DESCRIPTION
killall returns a non-zero exit code if there is no process to kill