### PR TITLE
Temporary hotfix for youtube-dl takedown. Subject to break due to no …

### DIFF
--- a/packages/sx05re/tools/video/youtube-dl/package.mk
+++ b/packages/sx05re/tools/video/youtube-dl/package.mk
@@ -2,11 +2,11 @@
 # Copyright (C) 2020-present Shanti Gilbert (https://github.com/shantigilbert)
 
 PKG_NAME="youtube-dl"
-PKG_VERSION="2020.06.16.1"
-PKG_SHA256="3062fcc8e511cec6ebbf58c87894bb64273d4668cc584439e4c722b76ff0c9eb"
+PKG_VERSION="latest"
+PKG_SHA256="b5660fa8441337c6b75448550bd6dcc7f97fe966b4ebb9bf47ff2b1cd4e3633a"
 PKG_LICENSE="The Unlicense"
-PKG_SITE="https://github.com/ytdl-org/youtube-dl"
-PKG_URL="${PKG_SITE}/releases/download/${PKG_VERSION}/youtube-dl"
+PKG_SITE="https://youtube-dl.org"
+PKG_URL="${PKG_SITE}/downloads/${PKG_VERSION}/youtube-dl"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="Command-line program to download videos from YouTube.com and other video sites"
 PKG_TOOLCHAIN="manual"


### PR DESCRIPTION
…version stamping on current download server

youtube-dl is getting DMCA'd. Sources were removed from Github and others. There's a temporary download location on the site, but only the source tarball is version stamped. I'm not very familiar with the ELEC's. A more appropriate solution would be to download the tarball, and build the final script from the original source.

But this fixes the build for the time being.