### PR TITLE
 Disable digital to analog on Flycast

### DIFF
--- a/packages/sx05re/emuelec/config/retroarch/config/remappings/Flycast/Flycast.rmp
+++ b/packages/sx05re/emuelec/config/retroarch/config/remappings/Flycast/Flycast.rmp
@@ -1,0 +1,5 @@
+input_player1_analog_dpad_mode = "0"
+input_player2_analog_dpad_mode = "0"
+input_player3_analog_dpad_mode = "0"
+input_player4_analog_dpad_mode = "0"
+input_player5_analog_dpad_mode = "0"


### PR DESCRIPTION
Solve joystick problems in Flycast. Tested on OGA and S905x3.