### PR TITLE
duckstation: version bump + fix default options

### DIFF
--- a/packages/sx05re/emulators/duckstation/package.mk
+++ b/packages/sx05re/emulators/duckstation/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2020-present Shanti Gilbert (https://github.com/shantigilbert)
 
 PKG_NAME="duckstation"
-PKG_VERSION="8432050094a485fbdf94ed79fe3eb7764612e9ca"
-PKG_SHA256="6bcd81596a78ef92c5558e038ed3f6c4e9a544c19cead9f887a667ea00d97c45"
+PKG_VERSION="b3bf9f3f10d86078fd69e060e3d98c80b6cde4cd"
+PKG_SHA256="f342f3a24f86a73d91a03beef015abd4852e792706b6984f774f9d35194d0d4a"
 PKG_ARCH="aarch64"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/stenzek/duckstation"
@@ -15,7 +15,10 @@ PKG_TOOLCHAIN="cmake"
 PKG_BUILD_FLAGS="-lto"
 
 pre_configure_target() {
- PKG_CMAKE_OPTS_TARGET+=" -DCMAKE_BUILD_TYPE=Release -DBUILD_LIBRETRO_CORE=ON "
+# PKG_CMAKE_OPTS_TARGET+=" -DCMAKE_BUILD_TYPE=Release -DBUILD_LIBRETRO_CORE=ON "
+ PKG_CMAKE_OPTS_TARGET+=" -DBUILD_LIBRETRO_CORE=ON -DBUILD_QT_FRONTEND=OFF -DBUILD_SDL_FRONTEND=OFF -DCMAKE_BUILD_TYPE=Release -DENABLE_DISCORD_PRESENCE=OFF -DUSE_SDL=OFF -DUSE_EGL=OFF -DUSE_X11=OFF -DUSE_WAYLAND=OFF"
+ sed -i ../src/duckstation-libretro/libretro_host_interface.cpp -e 's/   "OpenGL"/   "Software"/'
+ sed -i ../src/duckstation-libretro/libretro_host_interface.cpp -e 's/   "Info"}/   "None"}/'
 }
 
 makeinstall_target() {


### PR DESCRIPTION
duckstation in the dev branch performed horribly. Also rev bump to a know good version that performs well. We patch the default config in code so software rendering is defaulted which is what we want. Also turns off excess logging to save I/O calls.