### PR TITLE
Bump RigelEngine to latest release (0.7.1)

### DIFF
--- a/packages/sx05re/emuelec-ports/rigelengine/package.mk
+++ b/packages/sx05re/emuelec-ports/rigelengine/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2020-present Nikolai Wuttke (https://github.com/lethal-guitar)
 
 PKG_NAME="rigelengine"
-PKG_VERSION="3106f6078757c8d7a772a378841ffe598c81f014"
+PKG_VERSION="5511365e2a8ca4c9b09063f427e7bf1a66af9521"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"


### PR DESCRIPTION
Bumps RigelEngine to the new version I've just released, which fixes a few bugs. See [release notes](https://github.com/lethal-guitar/RigelEngine/releases/tag/v0.7.1-beta)