### PR TITLE
Update kernel patch to fix for 1024x768 resolution

### DIFF
--- a/projects/Amlogic-ng/patches/linux/linux-z93-emuelec-refresh-rate-fix-1024x768p60hz.patch
+++ b/projects/Amlogic-ng/patches/linux/linux-z93-emuelec-refresh-rate-fix-1024x768p60hz.patch
@@ -1,66 +1,131 @@
-From ed760ed3f34103d290ed1c946ecb0e51702a17b4 Mon Sep 17 00:00:00 2001
+From eb2e483ab16c0399071aa3114a99bd803dc101d4 Mon Sep 17 00:00:00 2001
 From: Dongjin Kim <tobetter@gmail.com>
-Date: Wed, 4 Nov 2020 02:09:02 +0900
-Subject: [PATCH] ODROID-COMMON: vout/hdmitx: fix invalid HDMI clock for
- '1024x768p60hz'
+Date: Sat, 9 Jan 2021 18:59:03 +0900
+Subject: [PATCH] media/hdmitx: improve 1024x768p60hz support
+
+This patch will fix the issue of distrosed picture at 60.xHz with
+certain display hardwares.
 
 Signed-off-by: Dongjin Kim <tobetter@gmail.com>
 ---
- .../media/vout/hdmitx/hdmi_tx_20/hw/hw_clk.c      |  2 +-
- .../media/vout/hdmitx/hdmi_tx_20/hw/hw_g12a.c     | 15 +++++++++++++++
- 2 files changed, 16 insertions(+), 1 deletion(-)
+ .../vout/hdmitx/hdmi_tx_20/hw/hdmi_tx_hw.c    | 16 +++++
+ .../media/vout/hdmitx/hdmi_tx_20/hw/hw_clk.c  |  2 +-
+ .../media/vout/hdmitx/hdmi_tx_20/hw/hw_g12a.c | 68 ++++++++++++++++++-
+ 3 files changed, 84 insertions(+), 2 deletions(-)
 
-diff --git a/drivers/amlogic/media/vout/hdmitx/hdmi_tx_20/hw/hw_clk.c b/drivers/amlogic/media/vout/hdmitx/hdmi_tx_20/hw/hw_clk.c
-index 4527f3ab6ab80..b62a2cc305d8c 100644
---- a/drivers/amlogic/media/vout/hdmitx/hdmi_tx_20/hw/hw_clk.c
-+++ b/drivers/amlogic/media/vout/hdmitx/hdmi_tx_20/hw/hw_clk.c
-@@ -842,7 +842,7 @@ static struct hw_enc_clk_val_group setting_enc_clk_val_24[] = {
- 		4115866, 4, 2, 1, VID_PLL_DIV_5, 2, 1, 1, -1},
- 	{{HDMIV_1024x768p60hz,
- 	  HDMI_VIC_END},
--		5200000, 4, 2, 1, VID_PLL_DIV_5, 2, 1, 1, -1},
-+		2600000, 2, 2, 1, VID_PLL_DIV_5, 2, 1, 1, -1},
- 	{{HDMIV_1280x768p60hz,
- 	  HDMI_VIC_END},
- 		3180000, 4, 1, 1, VID_PLL_DIV_5, 2, 1, 1, -1},
-diff --git a/drivers/amlogic/media/vout/hdmitx/hdmi_tx_20/hw/hw_g12a.c b/drivers/amlogic/media/vout/hdmitx/hdmi_tx_20/hw/hw_g12a.c
-index b7fa53cea9e12..1b88299eb84ca 100644
---- a/drivers/amlogic/media/vout/hdmitx/hdmi_tx_20/hw/hw_g12a.c
-+++ b/drivers/amlogic/media/vout/hdmitx/hdmi_tx_20/hw/hw_g12a.c
-@@ -323,6 +323,21 @@ void set_g12a_hpll_clk_out(unsigned int frac_rate, unsigned int clk)
- 		WAIT_FOR_PLL_LOCKED(P_HHI_HDMI_PLL_CNTL0);
- 		pr_info("HPLL: 0x%x\n", hd_read_reg(P_HHI_HDMI_PLL_CNTL0));
+diff --git a/drivers/amlogic/media/vout/hdmitx/hdmi_tx_20/hw/hdmi_tx_hw.c b/drivers/amlogic/media/vout/hdmitx/hdmi_tx_20/hw/hdmi_tx_hw.c
+index beae6aea4c9b..4c34abcca8b9 100644
+--- a/drivers/amlogic/media/vout/hdmitx/hdmi_tx_20/hw/hdmi_tx_hw.c
++++ b/drivers/amlogic/media/vout/hdmitx/hdmi_tx_20/hw/hdmi_tx_hw.c
+@@ -1705,6 +1705,22 @@ static void hdmi_tvenc_set(struct hdmitx_vidpara *param)
+ 		SOF_LINES = 28;
+ 		TOTAL_FRAMES = 4;
  		break;
-+	case 2600000:
-+		hd_write_reg(P_HHI_HDMI_PLL_CNTL0, 0x3b00046C);
-+		if (frac_rate)
-+			hd_write_reg(P_HHI_HDMI_PLL_CNTL1, 0x000140b4);
-+		else
-+			hd_write_reg(P_HHI_HDMI_PLL_CNTL1, 0x00018000);
-+		hd_write_reg(P_HHI_HDMI_PLL_CNTL2, 0x00000000);
-+		hd_write_reg(P_HHI_HDMI_PLL_CNTL3, 0x0a691c00);
-+		hd_write_reg(P_HHI_HDMI_PLL_CNTL4, 0x33771290);
-+		hd_write_reg(P_HHI_HDMI_PLL_CNTL5, 0x39270000);
-+		hd_write_reg(P_HHI_HDMI_PLL_CNTL6, 0x50540000);
-+		hd_set_reg_bits(P_HHI_HDMI_PLL_CNTL0, 0x0, 29, 1);
-+		WAIT_FOR_PLL_LOCKED(P_HHI_HDMI_PLL_CNTL0);
-+		pr_info("HPLL: 0x%x\n", hd_read_reg(P_HHI_HDMI_PLL_CNTL0));
++	case HDMIV_1024x768p60hz:
++		INTERLACE_MODE = 0;
++		PIXEL_REPEAT_VENC = 0;
++		PIXEL_REPEAT_HDMI = 0;
++		ACTIVE_PIXELS = (1024*(1+PIXEL_REPEAT_HDMI));
++		ACTIVE_LINES = (768/(1+INTERLACE_MODE));
++		LINES_F0 = 806;
++		LINES_F1 = 806;
++		FRONT_PORCH = 24;
++		HSYNC_PIXELS = 136;
++		BACK_PORCH = 160;
++		EOF_LINES = 3;
++		VSYNC_LINES = 6;
++		SOF_LINES = 29;
++		TOTAL_FRAMES = 4;
 +		break;
  	default:
- 		pr_info("error hpll clk: %d\n", clk);
  		break;
-
-diff --git a/drivers/amlogic/media/vout/hdmitx/hdmi_tx_20/hdmi_tx_main.c b/drivers/amlogic/media/vout/hdmitx/hdmi_tx_20/hdmi_tx_main.c
-index fdbb106042ef2..1f51137b22360 100644
---- a/drivers/amlogic/media/vout/hdmitx/hdmi_tx_20/hdmi_tx_main.c
-+++ b/drivers/amlogic/media/vout/hdmitx/hdmi_tx_20/hdmi_tx_main.c
-@@ -6044,7 +6044,7 @@ static int amhdmitx_probe(struct platform_device *pdev)
- 	hdmitx_extcon_register(pdev, dev);
+ 	}
+diff --git a/drivers/amlogic/media/vout/hdmitx/hdmi_tx_20/hw/hw_g12a.c b/drivers/amlogic/media/vout/hdmitx/hdmi_tx_20/hw/hw_g12a.c
+index e46b964491b8..9b24cc61f3f9 100644
+--- a/drivers/amlogic/media/vout/hdmitx/hdmi_tx_20/hw/hw_g12a.c
++++ b/drivers/amlogic/media/vout/hdmitx/hdmi_tx_20/hw/hw_g12a.c
+@@ -192,6 +192,29 @@ static void set_hpll_hclk_dongle_5940m(void)
+ 	pr_info("HPLL: 0x%x\n", hd_read_reg(P_HHI_HDMI_PLL_CNTL0));
+ }
  
- 	/* update fmt_attr */
--	/*hdmitx_init_fmt_attr(&hdmitx_device); /**/
-+	hdmitx_init_fmt_attr(&hdmitx_device);
- 
- 	hdmitx_device.task = kthread_run(hdmi_task_handle,
- 		&hdmitx_device, "kthread_hdmi");
++#define XTAL_FREQ               24000
++#define HDMI_FRAC_MAX_G12A      131072
++
++static unsigned int get_g12a_pll_get_frac(unsigned int m, unsigned int pll_freq)
++{
++	unsigned int parent_freq = XTAL_FREQ;
++	unsigned int frac_max = HDMI_FRAC_MAX_G12A;
++	unsigned int frac_m;
++	unsigned int frac;
++
++	if (pll_freq / m == parent_freq &&
++			pll_freq % m == 0)
++		return 0;
++
++	frac = div_u64((u64)pll_freq * (u64)frac_max, parent_freq);
++	frac_m = m * frac_max;
++	if (frac_m > frac)
++		return frac_max;
++	frac -= frac_m;
++
++	return min((u16)frac, (u16)(frac_max - 1));
++}
++
+ void set_g12a_hpll_clk_out(unsigned int frac_rate, unsigned int clk)
+ {
+ 	struct hdmitx_dev *hdev = get_hdmitx_device();
+@@ -366,7 +389,50 @@ void set_g12a_hpll_clk_out(unsigned int frac_rate, unsigned int clk)
+ 		pr_info("HPLL: 0x%x\n", hd_read_reg(P_HHI_HDMI_PLL_CNTL0));
+ 		break;
+ 	default:
+-		pr_info("error hpll clk: %d\n", clk);
++		{
++			unsigned int m, m1, m2;
++			unsigned int ret;
++			unsigned int frac;
++
++			/* calculate m */
++			m = clk / XTAL_FREQ;
++			m &= 0xff;
++			hd_write_reg(P_HHI_HDMI_PLL_CNTL0, (m | 0x3b000400));
++			pr_info("m1 0x%x, m2 0x%x, m 0x%x\n", m1, m2, m);
++
++			/* calculate frac */
++			frac = get_g12a_pll_get_frac(m, clk);
++			pr_info("m 0x%x, frac 0x%x\n", m, frac);
++			hd_write_reg(P_HHI_HDMI_PLL_CNTL1, frac);
++			hd_write_reg(P_HHI_HDMI_PLL_CNTL2, 0x00000000);
++
++			if (m >= 0xf7) {
++				if (frac < 0x10000) {
++					hd_write_reg(P_HHI_HDMI_PLL_CNTL3, 0x6a685c00);
++					hd_write_reg(P_HHI_HDMI_PLL_CNTL4, 0x11551293);
++				} else {
++					hd_write_reg(P_HHI_HDMI_PLL_CNTL3, 0xea68dc00);
++					hd_write_reg(P_HHI_HDMI_PLL_CNTL4, 0x65771290);
++				}
++				hd_write_reg(P_HHI_HDMI_PLL_CNTL5, 0x39270000);
++				hd_write_reg(P_HHI_HDMI_PLL_CNTL6, 0x55540000);
++			} else {
++				hd_write_reg(P_HHI_HDMI_PLL_CNTL3, 0x0a691c00);
++				hd_write_reg(P_HHI_HDMI_PLL_CNTL4, 0x33771290);
++				hd_write_reg(P_HHI_HDMI_PLL_CNTL5, 0x39270000);
++				hd_write_reg(P_HHI_HDMI_PLL_CNTL6, 0x50540000);
++			}
++
++			hd_set_reg_bits(P_HHI_HDMI_PLL_CNTL0, 0x0, 29, 1);
++			WAIT_FOR_PLL_LOCKED(P_HHI_HDMI_PLL_CNTL0);
++			pr_info("HPLL: 0x%x\n", hd_read_reg(P_HHI_HDMI_PLL_CNTL0));
++
++			ret = (((hd_read_reg(P_HHI_HDMI_PLL_CNTL0) >> 30) & 0x3) == 0x3);
++			if (ret)
++				pr_info("[%s] HPLL set OK!\n", __func__);
++			else
++				pr_info("[%s] Error! Check HPLL track!\n", __func__);
++		}
+ 		break;
+ 	}
+ }
+-- 
+2.25.1
 


### PR DESCRIPTION
Certain 1024x768 panel displays its refresh rate as 63~64Hz rather than 60Hz, this change can correct it.