### PR TITLE
Query SDL controller DB env var on SDL v 2.0.9

### DIFF
--- a/packages/sx05re/emuelec-ports/rigelengine/patches/001-controllerdbsdl209.patch
+++ b/packages/sx05re/emuelec-ports/rigelengine/patches/001-controllerdbsdl209.patch
@@ -1,0 +1,20 @@
+diff --git a/src/game_main.cpp b/src/game_main.cpp
+index 4be806c..cb89232 100644
+--- a/src/game_main.cpp
++++ b/src/game_main.cpp
+@@ -201,6 +201,15 @@ void gameMain(const CommandLineOptions& options) {
+     SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_GAMECONTROLLER));
+   auto sdlGuard = defer([]() { SDL_Quit(); });
+ 
++  SDL_version version;
++  SDL_GetVersion(&version);
++
++  if (version.patch < 10) {
++    if (const auto pMappingsFile = SDL_getenv("SDL_GAMECONTROLLERCONFIG_FILE")) {
++      SDL_GameControllerAddMappingsFromFile(pMappingsFile);
++    }
++  }
++
+   sdl_utils::check(SDL_GL_LoadLibrary(nullptr));
+   platform::setGLAttributes();
+ 


### PR DESCRIPTION
SDL 2.0.9 doesn't have the env var yet. Since EmuELEC is using
SDL 2.0.9 on non-OGA systems, we add a bit of code to explicitly
query the env var ourselves in case we're running on SDL 2.0.9.
This makes sure that custom game controller mappings can be found
by RigelEngine.