### PR TITLE
Support for mods with doom similar to ECWolf

### DIFF
--- a/packages/sx05re/emuelec-emulationstation/config/es_systems.cfg
+++ b/packages/sx05re/emuelec-emulationstation/config/es_systems.cfg
@@ -1961,8 +1961,8 @@ All systems must be contained within the <systemList> tag.-->
 		<manufacturer>id</manufacturer>
 		<release>1993</release>
 		<hardware>computer</hardware>
-		<path>/storage/roms/ports/doom</path>
-		<extension>.wad .WAD .iwad .IWAD .pwad .PWAD</extension>
+		<path>/storage/roms/ports/doom/games</path>
+		<extension>.wad .WAD .iwad .IWAD .pwad .PWAD .choco</extension>
 		<command>emuelecRunEmu.sh %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers="%CONTROLLERSCONFIG%"</command>
 		<platform>pc</platform>
 		<theme>prboom</theme>

--- a/packages/sx05re/emuelec-emulationstation/config/es_systems.cfg
+++ b/packages/sx05re/emuelec-emulationstation/config/es_systems.cfg
@@ -1961,7 +1961,7 @@ All systems must be contained within the <systemList> tag.-->
 		<manufacturer>id</manufacturer>
 		<release>1993</release>
 		<hardware>computer</hardware>
-		<path>/storage/roms/ports/doom/games</path>
+		<path>/storage/roms/ports/doom</path>
 		<extension>.wad .WAD .iwad .IWAD .pwad .PWAD .choco</extension>
 		<command>emuelecRunEmu.sh %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers="%CONTROLLERSCONFIG%"</command>
 		<platform>pc</platform>

--- a/packages/sx05re/emuelec-ports/chocolate-doom/scripts/chocodoom.sh
+++ b/packages/sx05re/emuelec-ports/chocolate-doom/scripts/chocodoom.sh
@@ -5,19 +5,59 @@
 
 . /etc/profile
 
-CONFIG="/emuelec/configs/chocolate-doom"
+RUN_DIR="/storage/roms/ports/doom"
+CONFIG_DIR="/emuelec/configs/chocolate-doom"
 LOCALCONFIG="/storage/.local/share/chocolate-doom"
+
+params=" --savedir ${CONFIG_DIR}"
 
 if [ ! -L "${LOCALCONFIG}" ]; then 
 [[ -d "${LOCALCONFIG}" ]] && rm -rf "${LOCALCONFIG}"
-ln -sf "${CONFIG}" "${LOCALCONFIG}"
+ln -sf "${CONFIG_DIR}" "${LOCALCONFIG}"
 fi
 
 GUID=$(echo "${2}" | grep -Ewo '[[:xdigit:]]{32}' | head -n1)
 # echo "Will use controller with ${GUID}"
 # Try to set up gamepad
-sed -i "s|joystick_guid.*|joystick_guid                 \"${GUID}\"|" "${CONFIG}/chocolate-doom.cfg"
+sed -i "s|joystick_guid.*|joystick_guid                 \"${GUID}\"|" "${CONFIG_DIR}/chocolate-doom.cfg"
 
-/usr/bin/chocolate-doom -iwad "${1}"
+# EXT can be wad, WAD, iwad, IWAD, pwad, PWAD or choco
+FILE=$(basename -- "${1}")
+EXT=${1#*.}
 
+# If its not a simple wad (extension .choco) read the file and parse the data
+if [ ${EXT} == "choco" ]; then
+    while IFS== read -r key value; do
+	if [ "$key" == "GAMETYPE" ]; then
+	    case ${value} in
+		"doom"|"DOOM")
+		    PROGRAM="chocolate-doom"
+		;;
+		"heretic"|"HERETIC")
+		    PROGRAM="chocolate-heretic"
+		;;
+		"hexen"|"HEXEN")
+		    PROGRAM="chocolate-hexen"
+		;;
+		"strife"|"STRIFE")
+		    PROGRAM="chocolate-strife"
+		;;
+	    esac
+	fi
+
+        if [ "$key" == "SUBDIR" ]; then
+	    RUN_DIR="/storage/roms/ports/doom/$value"
+        fi
+
+        if [ "$key" == "PARAMS" ]; then
+            params+=" $value"
+        fi
+    done < "${1}"
+else
+    PROGRAM="chocolate-doom"
+    params+=" -iwad ${RUN_DIR}/${FILE}"
+fi
+
+cd "${RUN_DIR}"
+/usr/bin/${PROGRAM} ${params} >/emuelec/logs/emuelec.log 2>&1
 

--- a/packages/sx05re/emuelec-ports/chocolate-doom/scripts/chocodoom.sh
+++ b/packages/sx05re/emuelec-ports/chocolate-doom/scripts/chocodoom.sh
@@ -42,6 +42,9 @@ if [ ${EXT} == "choco" ]; then
 		"strife"|"STRIFE")
 		    PROGRAM="chocolate-strife"
 		;;
+		*)
+		    PROGRAM="chocolate-doom"
+		;;
 	    esac
 	fi
 

--- a/packages/sx05re/emuelec-ports/chocolate-doom/scripts/chocodoom.sh
+++ b/packages/sx05re/emuelec-ports/chocolate-doom/scripts/chocodoom.sh
@@ -58,7 +58,7 @@ if [ ${EXT} == "choco" ]; then
     done < "${1}"
 else
     PROGRAM="chocolate-doom"
-    params+=" -iwad ${RUN_DIR}/${FILE}"
+    params+=" -iwad ${1}"
 fi
 
 cd "${RUN_DIR}"

--- a/packages/sx05re/emuelec/bin/emustation-config
+++ b/packages/sx05re/emuelec/bin/emustation-config
@@ -295,4 +295,17 @@ for ecwolf in SOD sod WL6 wl6 N3D n3d SD2 sd2 SD3 sd3; do
     fi
 done
 
+#check if we have doom data installed
+doomdir="/storage/roms/ports/doom"
+
+mkdir -p ${doomdir}/games
+
+cd ${doomdir}
+for file in *.WAD *.wad *.IWAD *.iwad *.PWAD *.pwad; do
+	[ -e "$file" ] || continue
+	if [ ! -f ${doomdir}/games/${file} ]; then
+		cp $file ${doomdir}/games
+	fi
+done
+
 exit 0

--- a/packages/sx05re/emuelec/bin/emustation-config
+++ b/packages/sx05re/emuelec/bin/emustation-config
@@ -295,17 +295,4 @@ for ecwolf in SOD sod WL6 wl6 N3D n3d SD2 sd2 SD3 sd3; do
     fi
 done
 
-#check if we have doom data installed
-doomdir="/storage/roms/ports/doom"
-
-mkdir -p ${doomdir}/games
-
-cd ${doomdir}
-for file in *.WAD *.wad *.IWAD *.iwad *.PWAD *.pwad; do
-	[ -e "$file" ] || continue
-	if [ ! -f ${doomdir}/games/${file} ]; then
-		cp $file ${doomdir}/games
-	fi
-done
-
 exit 0

--- a/packages/sx05re/emuelec/tmpfiles.d/emuelec-dirs.conf
+++ b/packages/sx05re/emuelec/tmpfiles.d/emuelec-dirs.conf
@@ -103,6 +103,7 @@ d    /storage/roms/ports/quake	        0777 root root - -
 d    /storage/roms/ports/diablo	        0777 root root - -
 d    /storage/roms/ports/doom	        0777 root root - -
 d    /storage/roms/ports/doom2	        0777 root root - -
+d    /storage/roms/ports/doom-mods      0777 root root - -
 d    /storage/roms/ports/cannonball     0777 root root - -
 d    /storage/roms/ports/CaveStory	    0777 root root - -
 d    /storage/roms/ports/reminiscence   0777 root root - -


### PR DESCRIPTION
This works really good but somehow 'breaks' the usage of libretro prboom. I had to copy the wad, iwad, pwad files to the subdir games. This way at least those still work with prboom. Calling .choco files with prboom gives an error.