### PR TITLE
Hopefully the last fix for setting brightness.

### DIFF
--- a/projects/Rockchip/devices/OdroidGoAdvance/packages/odroidgoa-utils/sources/odroidgoa_utils.sh
+++ b/projects/Rockchip/devices/OdroidGoAdvance/packages/odroidgoa-utils/sources/odroidgoa_utils.sh
@@ -64,7 +64,7 @@ if [ "${1}" == "bright" ]; then
 STEPS="5"
 CURBRIGHT=$(cat /sys/class/backlight/backlight/brightness)
 MAXSYSBRIGHT=$(cat /sys/class/backlight/backlight/max_brightness)
-CURRENTBRIGHT=$(($CURBRIGHT*100/$MAXSYSBRIGHT))
+CURRENTBRIGHT=$(awk -v a="$CURBRIGHT" -v b="$MAXSYSBRIGHT" 'BEGIN{print int(a*100/b)}')
 MAXBRIGHT="100"
 MINBRIGHT="2"
 
@@ -80,7 +80,7 @@ MINBRIGHT="2"
     [ "$STEPBRIGHT" -le "$MINBRIGHT" ] && STEPBRIGHT="$MINBRIGHT"
     #echo "Setting bright to $STEPBRIGHT"
 
-NEWVAL=$(($STEPBRIGHT*$MAXSYSBRIGHT/100))
+NEWVAL=$(awk -v a="$STEPBRIGHT" -v b="$MAXSYSBRIGHT" 'BEGIN{print int(a*b/100)}')
 echo "${NEWVAL}" > /sys/class/backlight/backlight/brightness
 set_ee_setting "brightness.level" $STEPBRIGHT
 fi


### PR DESCRIPTION
Since math in bash only uses integer, there were rounding errors. Now using awk for the math.