### PR TITLE
Fix drastic game saves & save states erased when resetting scripts & binaries to default

### DIFF
--- a/packages/sx05re/emuelec/bin/emuelec-utils
+++ b/packages/sx05re/emuelec/bin/emuelec-utils
@@ -12,12 +12,12 @@ function error() {
 }
 
 function audio() {
-	# This has to be expanded to check for new GLX devices running on Amlogic-ng, 
+	# This has to be expanded to check for new GLX devices running on Amlogic-ng,
 	# but right now its mostly used on ES to change audio to alsa before launching or else ES hangs on GXL devices.
-   if [[ "$1" == "alsa" ]]; then 
+   if [[ "$1" == "alsa" ]]; then
 		set_audio alsa
    elif [[ "$1" == "pulse" ]]; then
-		set_audio pulseaudio 
+		set_audio pulseaudio
    else
 		set_audio auto
    fi
@@ -54,11 +54,11 @@ function clearconfig() {
 function ee_backup() {
 	BACKUPFILE="ee_backup_config.tar.gz"
 
-    if mountpoint -q /var/media/EEROMS; then 
-        mkdir -p "/var/media/EEROMS/backup" 
-        BACKUPFILE="/var/media/EEROMS/backup/${BACKUPFILE}" 
-    elif mountpoint -q /storage/roms; then 
-        mkdir -p "/storage/roms/backup" 
+    if mountpoint -q /var/media/EEROMS; then
+        mkdir -p "/var/media/EEROMS/backup"
+        BACKUPFILE="/var/media/EEROMS/backup/${BACKUPFILE}"
+    elif mountpoint -q /storage/roms; then
+        mkdir -p "/storage/roms/backup"
         BACKUPFILE="/storage/roms/backup/${BACKUPFILE}"
     fi
 
@@ -88,8 +88,9 @@ function ee_backup() {
 					  /storage/.config/retroarch/config/* \
 					  /storage/.config/supertux* \
 					  /storage/.emulationstation/scripts/drastic/config/* \
-					  /storage/.emulationstation/scripts/drastic/*.dsv \
-                      /storage/.config/emuelec/bin/pico-8/*
+					  /storage/.emulationstation/scripts/drastic/backup/* \
+					  /storage/.emulationstation/scripts/drastic/savestates/* \
+					  /storage/.config/emuelec/bin/pico-8/*
         sync
 		sleep 3
 		[ -z "${2}" ] && systemctl start emustation
@@ -102,15 +103,15 @@ function filemanager() {
 }
 
 function getshaders() {
-	find /tmp/shaders -name '*.glslp' -print0 | 
-		while IFS= read -r -d '' line; do 
+	find /tmp/shaders -name '*.glslp' -print0 |
+		while IFS= read -r -d '' line; do
 		echo ${line#/tmp/shaders/},
 	done
 }
 
 function getip() {
 IP="$(ifconfig wlan0 | grep 'inet addr' | cut -d: -f2 | awk '{print $1}')"
-  
+
   if [ -z "$IP" ]; then
 	 IP="$(ifconfig eth0 | grep 'inet addr' | cut -d: -f2 | awk '{print $1}')"
   fi
@@ -186,11 +187,11 @@ function small-cores() {
     fi
 }
 
-function unmount_all () { 
+function unmount_all () {
     if /usr/bin/busybox mountpoint -q /emuelec/themes ; then
         umount /emuelec/themes > /dev/null 2>&1
     fi
-    
+
     if /usr/bin/busybox mountpoint -q /storage/roms ; then
         umount /storage/roms > /dev/null 2>&1
     fi


### PR DESCRIPTION
Fixes #589

Drastic save folders observed in EmuELEC `4.0`:
- `/storage/.config/emulationstation/scripts/drastic/backup`
- `/storage/.config/emulationstation/scripts/drastic/savestates`

![1](https://user-images.githubusercontent.com/1018543/117011530-819c6080-ad20-11eb-9098-9baf03197423.jpg)
![2](https://user-images.githubusercontent.com/1018543/117011537-82cd8d80-ad20-11eb-9eca-1246e9f38328.jpg)


Current drastic script part added in
https://github.com/EmuELEC/EmuELEC/blame/4f16bfbac1a5941671f0d050fcd2c29cf6822475/packages/sx05re/emuelec/config/emuelec/scripts/ee_backup.sh
is 14 months ago and might be for old drastic versions and thus folder structure

Note: My editor strips all trailing spaces automatically