### PR TITLE
Add .editorconfig file & Rename CHANGELOG to have md suffix

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,31 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+# Default indent via 2 spaces
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.py]
+# Set default charset
+charset = utf-8
+# 4 space indentation, required by Python
+indent_style = space
+indent_size = 4
+
+# Tab indentation (no size specified)
+[Makefile]
+indent_style = tab
+
+[*.{md, markdown}]
+# Trailing space has meaning
+trim_trailing_whitespace = false
+[CHANGELOG]
+# Trailing space has meaning
+trim_trailing_whitespace = false


### PR DESCRIPTION
Lack of standard spotted in #595

Regardless the final content in `.editorconfig` 
I think having a standard declared and supported by editors is better
I have checked a few other emulation projects and they don't have this file
(But do they have mixed tab and spaces? I haven't checked)

The rename of `CHANGELOG` is to let editors know it's `*.md`
If you don't like I can rename it back and update the rule to include `CHANGELOG`