### PR TITLE
Issue #574 with setting brightness was still not fixed completely

### DIFF
--- a/packages/sx05re/emuelec/config/emuelec/configs/emuelec.conf
+++ b/packages/sx05re/emuelec/config/emuelec/configs/emuelec.conf
@@ -42,7 +42,7 @@ ee_splash.enabled=1
 advmame_auto_gamepad=1
 
 # OdroidGoAdvance Brightness Level
-brightness.level=255
+brightness.level=100
 
 ## EmulationStation menu style
 ## default -> default all options menu

--- a/projects/Rockchip/devices/GameForce/packages/odroidgoa-utils/sources/odroidgoa_utils.sh
+++ b/projects/Rockchip/devices/GameForce/packages/odroidgoa-utils/sources/odroidgoa_utils.sh
@@ -64,9 +64,9 @@ if [ "${1}" == "bright" ]; then
 STEPS="5"
 CURBRIGHT=$(cat /sys/class/backlight/backlight/brightness)
 MAXSYSBRIGHT=$(cat /sys/class/backlight/backlight/max_brightness)
-CURRENTBRIGHT=$(awk -v a="$CURBRIGHT" -v b="$MAXSYSBRIGHT" 'BEGIN{print int(a*100/b)}')
+CURRENTBRIGHT=$(awk -v a="$CURBRIGHT" -v b="$MAXSYSBRIGHT" 'BEGIN{print int((a*100/b)+0.5)}')
 MAXBRIGHT="100"
-MINBRIGHT="2"
+MINBRIGHT="5"
 
     if [ "${2}" == "+" ]; then
         STEPBRIGHT=$(($CURRENTBRIGHT+$STEPS))
@@ -80,7 +80,7 @@ MINBRIGHT="2"
     [ "$STEPBRIGHT" -le "$MINBRIGHT" ] && STEPBRIGHT="$MINBRIGHT"
     #echo "Setting bright to $STEPBRIGHT"
 
-NEWVAL=$(awk -v a="$STEPBRIGHT" -v b="$MAXSYSBRIGHT" 'BEGIN{print int(a*b/100)}')
+    NEWVAL=$(awk -v a="$STEPBRIGHT" -v b="$MAXSYSBRIGHT" 'BEGIN{print int((a*b/100)+0.5)}')
 echo "${NEWVAL}" > /sys/class/backlight/backlight/brightness
 set_ee_setting "brightness.level" $STEPBRIGHT
 fi

--- a/projects/Rockchip/devices/OdroidGoAdvance/packages/odroidgoa-utils/sources/odroidgoa_utils.sh
+++ b/projects/Rockchip/devices/OdroidGoAdvance/packages/odroidgoa-utils/sources/odroidgoa_utils.sh
@@ -64,9 +64,9 @@ if [ "${1}" == "bright" ]; then
 STEPS="5"
 CURBRIGHT=$(cat /sys/class/backlight/backlight/brightness)
 MAXSYSBRIGHT=$(cat /sys/class/backlight/backlight/max_brightness)
-CURRENTBRIGHT=$(awk -v a="$CURBRIGHT" -v b="$MAXSYSBRIGHT" 'BEGIN{print int(a*100/b)}')
+CURRENTBRIGHT=$(awk -v a="$CURBRIGHT" -v b="$MAXSYSBRIGHT" 'BEGIN{print int((a*100/b)+0.5)}')
 MAXBRIGHT="100"
-MINBRIGHT="2"
+MINBRIGHT="5"
 
     if [ "${2}" == "+" ]; then
         STEPBRIGHT=$(($CURRENTBRIGHT+$STEPS))
@@ -80,7 +80,7 @@ MINBRIGHT="2"
     [ "$STEPBRIGHT" -le "$MINBRIGHT" ] && STEPBRIGHT="$MINBRIGHT"
     #echo "Setting bright to $STEPBRIGHT"
 
-NEWVAL=$(awk -v a="$STEPBRIGHT" -v b="$MAXSYSBRIGHT" 'BEGIN{print int(a*b/100)}')
+    NEWVAL=$(awk -v a="$STEPBRIGHT" -v b="$MAXSYSBRIGHT" 'BEGIN{print int((a*b/100)+0.5)}')
 echo "${NEWVAL}" > /sys/class/backlight/backlight/brightness
 set_ee_setting "brightness.level" $STEPBRIGHT
 fi


### PR DESCRIPTION
Issue #574 was still not fixed completely. Brightness can be changed in two ways:
  1. in emulationstations System menu
  2. via hotkey
The calculation in emulationstation also had rounding errors. I made a PR in
batocera-linux/batocera-emulationstation which was just merged and fixes point 1.
To be consistent point 2. has to also be changed again.

If this PR is accepted and also the PR from batocera-linux/batocera-emulationstation
merged, brightness can then be changed with both methods in steps of 5 in a range from 5 to 100.
The value is correctly written to emuelec.conf and correctly restored after reboot.

The default value in emuelec.conf was set from 255 to 100. This is a %-value
with a maximum of 100.