### PR TITLE
Do not redirect stdout/stderr to /dev/null in maxperf and normperf.

### DIFF
--- a/packages/sx05re/emuelec/profile.d/99-emuelec.conf
+++ b/packages/sx05re/emuelec/profile.d/99-emuelec.conf
@@ -106,25 +106,25 @@ killall head
 maxperf() {
 	
 	if [ "$EE_DEVICE" == "OdroidGoAdvance" ] || [ "$EE_DEVICE" == "GameForce" ]; then
-		echo performance > /sys/devices/platform/ff400000.gpu/devfreq/ff400000.gpu/governor > /dev/null 2>&1
-		echo performance > /sys/devices/platform/dmc/devfreq/dmc/governor > /dev/null 2>&1
-		echo performance > /sys/devices/system/cpu/cpufreq/policy0/scaling_governor > /dev/null 2>&1
+		echo performance > /sys/devices/platform/ff400000.gpu/devfreq/ff400000.gpu/governor
+		echo performance > /sys/devices/platform/dmc/devfreq/dmc/governor
+		echo performance > /sys/devices/system/cpu/cpufreq/policy0/scaling_governor
 	else
-		echo "performance" > /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor > /dev/null 2>&1
-		echo "performance" > /sys/devices/system/cpu/cpu4/cpufreq/scaling_governor > /dev/null 2>&1
-		echo 5 > /sys/class/mpgpu/cur_freq > /dev/null 2>&1
+		echo "performance" > /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
+		echo "performance" > /sys/devices/system/cpu/cpu4/cpufreq/scaling_governor
+		echo 5 > /sys/class/mpgpu/cur_freq
 	fi
 }
 
 normperf() {
 	if [ "$EE_DEVICE" == "OdroidGoAdvance" ] || [ "$EE_DEVICE" == "GameForce" ]; then
-		echo simple_ondemand > /sys/devices/platform/ff400000.gpu/devfreq/ff400000.gpu/governor > /dev/null 2>&1
-		echo dmc_ondemand > /sys/devices/platform/dmc/devfreq/dmc/governor > /dev/null 2>&1
-		echo interactive > /sys/devices/system/cpu/cpufreq/policy0/scaling_governor > /dev/null 2>&1
+		echo simple_ondemand > /sys/devices/platform/ff400000.gpu/devfreq/ff400000.gpu/governor
+		echo dmc_ondemand > /sys/devices/platform/dmc/devfreq/dmc/governor
+		echo interactive > /sys/devices/system/cpu/cpufreq/policy0/scaling_governor
 	else
-		echo "ondemand" > /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor > /dev/null 2>&1
-		echo "ondemand" > /sys/devices/system/cpu/cpu4/cpufreq/scaling_governor > /dev/null 2>&1
-		echo 1 > /sys/class/mpgpu/cur_freq > /dev/null 2>&1
+		echo "ondemand" > /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
+		echo "ondemand" > /sys/devices/system/cpu/cpu4/cpufreq/scaling_governor
+		echo 1 > /sys/class/mpgpu/cur_freq
 	fi	
 }
 


### PR DESCRIPTION
This should fix maxperf and normperf not working as intended.