### PR TITLE
retroarch: Add GLES 3.2 support for rk3326 devices.

### DIFF
--- a/packages/sx05re/libretro/retroarch/package.mk
+++ b/packages/sx05re/libretro/retroarch/package.mk
@@ -69,6 +69,7 @@ PKG_CONFIGURE_OPTS_TARGET="--disable-qt \
 
 if [ "$DEVICE" == "OdroidGoAdvance" ] || [ "$DEVICE" == "GameForce" ]; then
 PKG_CONFIGURE_OPTS_TARGET+=" --enable-opengles3 \
+                           --enable-opengles3_2 \
                            --enable-kms \
                            --disable-mali_fbdev"
 else


### PR DESCRIPTION
This build flag declares GLES minor version support in RetroArch. This is important for cores that use the libretro API to find out GLES support. E.g. duckstation's HW renderer. Before this change:
```
[ERROR] Requesting OpenGLES3.2 context, but RetroArch is compiled against a lesser version. Cannot use HW context.
[ERROR] [Environ]: SET_HW_RENDER - Dynamic request HW context failed.
[INFO] [Environ]: SET_HW_RENDER, context type: gl.
[ERROR] Requesting OpenGLES3.1 context, but RetroArch is compiled against a lesser version. Cannot use HW context.
[ERROR] [Environ]: SET_HW_RENDER - Dynamic request HW context failed.
[INFO] [Environ]: SET_HW_RENDER, context type: gl.
[INFO] Requesting OpenGLES3 context.
[INFO] Reached end of SET_HW_RENDER.
```
(i.e. it fails to get a GLES 3.2 context and insteads get a GLES 3.0 context)
after:
```
[INFO] Requesting OpenGLES3.2 context.
[INFO] Reached end of SET_HW_RENDER.
```
(i.e., it successfully gets a GLES 3.2 context)

Tested with Gameforce Chi. Presume this works for OGA as they have the same chipset. Other devices may also need similar flags, FYI.

Thanks very much to @shantigilbert for supplying me a retroarch binary to test!