### PR TITLE
Support requires field in ports.yaml

### DIFF
--- a/packages/sx05re/emuelec-ports/sources/port_builder.py
+++ b/packages/sx05re/emuelec-ports/sources/port_builder.py
@@ -3,8 +3,26 @@
 import jinja2
 import yaml
 
-from os import getcwd, path
+from os import environ, getcwd, path
 from sys import argv
+
+def meets_requirements(data):
+    if not "requires" in data:
+        # No specific requirements
+        return True
+
+    for supported_setup in data["requires"]:
+        acceptable = True
+        for key, value in supported_setup.items():
+            if environ.get(key) != value:
+                acceptable = False
+                break
+
+        if acceptable:
+            return True
+
+    return False
+
 
 yaml_file = argv[1]
 try:
@@ -20,7 +38,9 @@ gamelist_template = templateEnv.get_template("gamelist.xml.j2")
 with open(yaml_file) as ports_file:
     ports = yaml.load(ports_file, Loader=yaml.SafeLoader)
 
-for name, data in ports.items():
+supported_ports = [port for port in ports.items() if meets_requirements(port[1])]
+
+for name, data in supported_ports:
     # Create port script
     with open(path.join(output_location, "{}.sh".format(name)), "w") as port_file:
         port_file.write(port_template.render(name=name, data=data))
@@ -28,5 +48,5 @@ for name, data in ports.items():
 
 # Create gamelist.xml
 with open(path.join(output_location, "gamelist.xml"), "w") as gamelist_file:
-    gamelist_file.write(gamelist_template.render(games=ports.items()))
+    gamelist_file.write(gamelist_template.render(games=supported_ports))
     gamelist_file.close()


### PR DESCRIPTION
The requires field will be looped over and every environment variable
will be checked. If any of the entries in requires have all named
environment variables matching the desired value, the port will be
labelled as supported.

Any arbitrary environment variable is supported. So using something like:
```
BetaGame:
  requires:
    - ENABLE_UNSTABLE_GAMES: 1
```
is also possible to require an environment variable named ENABLE_UNSTABLE_GAMES with value 1 set.

Hope this is flexible enough for you :)