### PR TITLE
Set display

### DIFF
--- a/packages/sx05re/emuelec/bin/emuelecRunEmu.sh
+++ b/packages/sx05re/emuelec/bin/emuelecRunEmu.sh
@@ -85,7 +85,7 @@ SET_DISPLAY_SH="/usr/bin/setres.sh" # source of set-display script.
 
 VIDEO=$(get_ee_setting global.videomode)
 [[ -z "$VIDEO" ]] && VIDEO=$(get_ee_setting ee_videomode)
-VIDEO_EMU=$(get_ee_setting ${PLATFORM}.nativevideo)
+VIDEO_EMU=$(get_ee_setting ${PLATFORM}.nativevideo ${PLATFORM})
 
 ROMNAME="$1"
 BASEROMNAME=${ROMNAME##*/}

--- a/packages/sx05re/emuelec/bin/emuelecRunEmu.sh
+++ b/packages/sx05re/emuelec/bin/emuelecRunEmu.sh
@@ -81,15 +81,14 @@ CORE="${CORE%% *}"  # until a space is found
 EMULATOR="${arguments##*--emulator=}"  # read from --emulator= onwards
 EMULATOR="${EMULATOR%% *}"  # until a space is found
 
-SET_DISPLAY_SH="/usr/bin/setres.sh" # source of set-display script.
-
-VIDEO=$(get_ee_setting global.videomode)
-[[ -z "$VIDEO" ]] && VIDEO=$(get_ee_setting ee_videomode)
-VIDEO_EMU=$(get_ee_setting ${PLATFORM}.nativevideo ${PLATFORM})
-
 ROMNAME="$1"
 BASEROMNAME=${ROMNAME##*/}
 GAMEFOLDER="${ROMNAME//${BASEROMNAME}}"
+
+[[ -f "/emuelec/bin/setres.sh" ]] && SET_DISPLAY_SH="/emuelec/bin/setres.sh" || SET_DISPLAY_SH="/usr/bin/setres.sh"
+VIDEO=$(get_ee_setting global.videomode)
+[[ -z "$VIDEO" ]] && VIDEO=$(get_ee_setting ee_videomode)
+VIDEO_EMU=$(get_ee_setting nativevideo "${PLATFORM}" "${BASEROMNAME}")
 
 if [[ "${CORE}" == *"_32b"* ]]; then
     BIT32="yes"

--- a/packages/sx05re/emuelec/bin/emuelecRunEmu.sh
+++ b/packages/sx05re/emuelec/bin/emuelecRunEmu.sh
@@ -81,6 +81,11 @@ CORE="${CORE%% *}"  # until a space is found
 EMULATOR="${arguments##*--emulator=}"  # read from --emulator= onwards
 EMULATOR="${EMULATOR%% *}"  # until a space is found
 
+SET_DISPLAY_SH="/usr/bin/setres.sh" # source of set-display script.
+VIDEO=$(get_ee_setting global.videomode)
+[[ -z "$VIDEO" ]] && VIDEO=$(get_ee_setting ee_videomode)
+VIDEO_EMU=$(get_ee_setting ${PLATFORM}.nativevideo)
+
 ROMNAME="$1"
 BASEROMNAME=${ROMNAME##*/}
 GAMEFOLDER="${ROMNAME//${BASEROMNAME}}"
@@ -148,6 +153,8 @@ fi
 SPL=$(get_ee_setting ee_splash.enabled)
 [ "$SPL" -eq "1" ] && ${TBASH} show_splash.sh "$PLATFORM" "${ROMNAME}"
 
+# Set the display video to that of the emulator setting.
+[[ -z "$VIDEO_EMU" ]] && source $SET_DISPLAY_SH $VIDEO_EMU # set display
 
 if [ -z ${LIBRETRO} ] && [ -z ${RETRORUN} ]; then
 
@@ -421,6 +428,9 @@ fi
 
 # Only run fbfix on Amlogic-ng (Mali g31 and g52 in Amlogic SOC)
 [[ "$EE_DEVICE" == "Amlogic-ng" ]] && fbfix
+
+# Revert the display video to that of the original emuelec setting.
+[[ -z "$VIDEO_EMU" ]] && source $SET_DISPLAY_SH $VIDEO # set display
 
 # Show exit splash
 ${TBASH} show_splash.sh exit

--- a/packages/sx05re/emuelec/bin/emuelecRunEmu.sh
+++ b/packages/sx05re/emuelec/bin/emuelecRunEmu.sh
@@ -82,6 +82,7 @@ EMULATOR="${arguments##*--emulator=}"  # read from --emulator= onwards
 EMULATOR="${EMULATOR%% *}"  # until a space is found
 
 SET_DISPLAY_SH="/usr/bin/setres.sh" # source of set-display script.
+
 VIDEO=$(get_ee_setting global.videomode)
 [[ -z "$VIDEO" ]] && VIDEO=$(get_ee_setting ee_videomode)
 VIDEO_EMU=$(get_ee_setting ${PLATFORM}.nativevideo)
@@ -154,7 +155,7 @@ SPL=$(get_ee_setting ee_splash.enabled)
 [ "$SPL" -eq "1" ] && ${TBASH} show_splash.sh "$PLATFORM" "${ROMNAME}"
 
 # Set the display video to that of the emulator setting.
-[[ -z "$VIDEO_EMU" ]] && source $SET_DISPLAY_SH $VIDEO_EMU # set display
+[[ ! -z "$VIDEO_EMU" ]] && source $SET_DISPLAY_SH $VIDEO_EMU # set display
 
 if [ -z ${LIBRETRO} ] && [ -z ${RETRORUN} ]; then
 
@@ -430,7 +431,7 @@ fi
 [[ "$EE_DEVICE" == "Amlogic-ng" ]] && fbfix
 
 # Revert the display video to that of the original emuelec setting.
-[[ -z "$VIDEO_EMU" ]] && source $SET_DISPLAY_SH $VIDEO # set display
+[[ ! -z "$VIDEO_EMU" ]] && source $SET_DISPLAY_SH $VIDEO # set display
 
 # Show exit splash
 ${TBASH} show_splash.sh exit

--- a/packages/sx05re/emuelec/bin/setres.sh
+++ b/packages/sx05re/emuelec/bin/setres.sh
@@ -4,77 +4,119 @@
 # Copyright (C) 2019-present Shanti Gilbert (https://github.com/shantigilbert)
 
 # Read the video output mode and set it for emuelec to avoid video flicking.
-MODE=`cat /sys/class/display/mode`;
-BPP=32
 
-if [ -e /ee_s905 ]; then
-case "$MODE" in
-"480p60hz")
-	fbset -fb /dev/fb0 -g 720 480 720 960 $BPP
-	;;
-"576p50hz")
-	fbset -fb /dev/fb0 -g 720 576 720 1152 $BPP
-	;;
-"720p60hz")
-	fbset -fb /dev/fb0 -g 1280 720 1280 1440 $BPP
-	;;
-"720p50hz")
-	echo 720p60hz > /sys/class/display/mode
-	fbset -fb /dev/fb0 -g 1280 720 1280 1440 $BPP
-	;;
-"1080p60hz")
-	fbset -fb /dev/fb0 -g 1920 1080 1920 2160 $BPP
-	;;
-"1080i60hz")
-	fbset -fb /dev/fb0 -g 1920 1080 1920 2160 $BPP
-	;;
-"1080i50hz")
-	echo 1080i60hz > /sys/class/display/mode
-	fbset -fb /dev/fb0 -g 1920 1080 1920 2160 $BPP
-	;;
-"1080p50hz")
-	echo 1080p60hz > /sys/class/display/mode
-	fbset -fb /dev/fb0 -g 1920 1080 1920 2160 $BPP
-	;;
-"1280x1024p60hz")
-	fbset -fb /dev/fb0 -g 1280 1024 1280 2048 $BPP
-	echo 0 0 1279 1023 > /sys/class/graphics/fb0/free_scale_axis
-	echo 0 0 1279 1023 > /sys/class/graphics/fb0/window_axis
-	echo 0x10001 > /sys/class/graphics/fb0/free_scale
-	;;
-"1024x768p60hz")
-	fbset -fb /dev/fb0 -g 1024 768 1024 1536 $BPP
-	echo 0 0 1023 767 > /sys/class/graphics/fb0/free_scale_axis
-	echo 0 0 1023 767 > /sys/class/graphics/fb0/window_axis
-	echo 0x10001 > /sys/class/graphics/fb0/free_scale
-	;;
-"640x480p60hz")
-	fbset -fb /dev/fb0 -g 640 480 640 960 $BPP
-	echo 0 0 639 479 > /sys/class/graphics/fb0/free_scale_axis
-	echo 0 0 639 479 > /sys/class/graphics/fb0/window_axis
-	echo 0x10001 > /sys/class/graphics/fb0/free_scale
-	;;
-"480cvbs")
-	fbset -fb /dev/fb0 -g 1280 960 1280 1920 $BPP
-	fbset -fb /dev/fb1 -g $BPP $BPP $BPP $BPP $BPP
-	echo 0 0 1279 959 > /sys/class/graphics/fb0/free_scale_axis
-	echo 30 10 669 469 > /sys/class/graphics/fb0/window_axis
-	echo 640 > /sys/class/graphics/fb0/scale_width
-	echo 480 > /sys/class/graphics/fb0/scale_height
-	echo 0x10001 > /sys/class/graphics/fb0/free_scale
-	;;
-"576cvbs")
-	fbset -fb /dev/fb0 -g 1280 960 1280 1920 $BPP
-	fbset -fb /dev/fb1 -g $BPP $BPP $BPP $BPP $BPP
-	echo 0 0 1279 959 > /sys/class/graphics/fb0/free_scale_axis
-	echo 35 20 680 565 > /sys/class/graphics/fb0/window_axis
-	echo 720 > /sys/class/graphics/fb0/scale_width
-	echo 576 > /sys/class/graphics/fb0/scale_height
-	echo 0x10001 > /sys/class/graphics/fb0/free_scale
-	;;
+# This file sets the hdmi output and frame buffer to the argument in pixel width.
+# Allowed argument example ./setres.sh 1080p60hz <-- For height 1080 pixels.
+
+# set -x #echo on
+
+# 1080p60hz
+# 1080i60hz
+# 720p60hz
+# 720p50hz
+# 480p60hz
+# 480cvbs
+# 576p50hz
+# 1080p50hz
+# 1080i50hz
+# 576cvbs
+
+BPP=32
+HZ=60
+
+MODE=$1
+
+[ -z "$MODE" ] && MODE=`cat /sys/class/display/mode`;
+
+case $MODE in
+	*p*) H=$(echo $MODE | cut -d'p' -f 1) ;;
+	*i*) H=$(echo $MODE | cut -d'i' -f 1) ;;
+	*cvbs*) H=$(echo $MODE | cut -d'c' -f 1) ;;
+	*hz*) HZ=${i:(-4):2} ;;
 esac
 
-fi 
+if [ $HZ = "50" ]; then
+	HZ=60
+fi
+
+# used for testing.
+#echo $MODE
+#echo $H
+#echo $HZ
+#exit 1
+
+case $i in
+	480p60hz)
+		W=720
+		DI=$(($H*2))
+		W1=$(($W-1))
+		H1=$(($H-1))
+		fbset -fb /dev/fb0 -g $W $H $W $DI $BPP
+		fbset -fb /dev/fb1 -g $BPP $BPP $BPP $BPP $BPP
+		MODE=$(echo "${H}p${HZ}hz")
+		echo $MODE > /sys/class/display/mode
+		echo 0 > /sys/class/graphics/fb0/free_scale
+		echo 1 > /sys/class/graphics/fb0/freescale_mode
+		echo 0 0 $W1 $H1 > /sys/class/graphics/fb0/free_scale_axis
+		echo 0 0 $W1 $H1 > /sys/class/graphics/fb0/window_axis
+		echo 0 > /sys/class/graphics/fb1/free_scale
+		;;
+	576p50hz|720p60hz|720p50hz|1080p60hz|1080i60hz|1080i50hz|1080p50hz)
+		W=$(($H*16/9))
+		DH=$(($H*2))
+		W1=$(($W-1))
+		H1=$(($H-1))
+		fbset -fb /dev/fb0 -g $W $H $W $DH $BPP
+		fbset -fb /dev/fb1 -g $BPP $BPP $BPP $BPP $BPP
+		MODE=$(echo "${H}p${HZ}hz")
+		echo $MODE > /sys/class/display/mode
+		echo 0 > /sys/class/graphics/fb0/free_scale
+		echo 1 > /sys/class/graphics/fb0/freescale_mode
+		echo 0 0 $W1 $H1 > /sys/class/graphics/fb0/free_scale_axis
+		echo 0 0 $W1 $H1 > /sys/class/graphics/fb0/window_axis
+		echo 0 > /sys/class/graphics/fb1/free_scale
+		;;
+	1280x1024p60hz|1024x768p60hz|640x480p60hz)
+		W=$(($W*4/3))
+		DH=$(($H*2))
+		W1=$(($W-1))
+		H1=$(($H-1))
+		fbset -fb /dev/fb0 -g $W $H $W $DH $BPP
+		fbset -fb /dev/fb1 -g $BPP $BPP $BPP $BPP $BPP
+		MODE=$(echo "${H}p${HZ}hz")
+		echo $MODE > /sys/class/display/mode
+		echo 0 > /sys/class/graphics/fb0/free_scale
+		echo 1 > /sys/class/graphics/fb0/freescale_mode
+		echo 0 0 $W1 $H1 > /sys/class/graphics/fb0/free_scale_axis
+		echo 0 0 $W1 $H1 > /sys/class/graphics/fb0/window_axis
+		echo 0 > /sys/class/graphics/fb1/free_scale
+		;;
+	480cvbs)
+		fbset -fb /dev/fb0 -g 1280 960 1280 1920 $BPP
+		fbset -fb /dev/fb1 -g $BPP $BPP $BPP $BPP $BPP
+		echo 0 0 1279 959 > /sys/class/graphics/fb0/free_scale_axis
+		echo 30 10 669 469 > /sys/class/graphics/fb0/window_axis
+		echo 640 > /sys/class/graphics/fb0/scale_width
+		echo 480 > /sys/class/graphics/fb0/scale_height
+		echo 0x10001 > /sys/class/graphics/fb0/free_scale
+		;;
+	576cvbs)
+		fbset -fb /dev/fb0 -g 1280 960 1280 1920 $BPP
+		fbset -fb /dev/fb1 -g $BPP $BPP $BPP $BPP $BPP
+		echo 0 0 1279 959 > /sys/class/graphics/fb0/free_scale_axis
+		echo 35 20 680 565 > /sys/class/graphics/fb0/window_axis
+		echo 720 > /sys/class/graphics/fb0/scale_width
+		echo 576 > /sys/class/graphics/fb0/scale_height
+		echo 0x10001 > /sys/class/graphics/fb0/free_scale
+		;;
+esac
+
+# Enable framebuffer device
+echo 0 > /sys/class/graphics/fb0/blank
+
+# Blank fb1 to prevent static noise
+echo 1 > /sys/class/graphics/fb1/blank
+
 # End of reading the video output mode and setting it for emuelec to avoid video flicking.
 # The codes can be simplified with "elseif" sentences.
 # The codes for 480I and 576I are adjusted to avoid overscan.

--- a/packages/sx05re/emuelec/bin/setres.sh
+++ b/packages/sx05re/emuelec/bin/setres.sh
@@ -45,7 +45,7 @@ fi
 #echo $HZ
 #exit 1
 
-case $i in
+case $MODE in
 	480p60hz)
 		W=720
 		DI=$(($H*2))


### PR DESCRIPTION
There is a bug in the call to get_ee_setting that it requires the platform prefix as well as the platform as a seperate argument:
e.g.
get_ee_setting nativevideo n64  <-- becomes blank
get_ee_setting n64.nativevideo n64 <-- works.


