### PR TITLE
Update SDL_Sound package.mk

### DIFF
--- a/packages/sx05re/tools/SDL2-git/SDL_sound/package.mk
+++ b/packages/sx05re/tools/SDL2-git/SDL_sound/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2018-present 5schatten (https://github.com/5schatten)
 
 PKG_NAME="SDL_sound"
-PKG_VERSION="f0d57c9b72d8"
-PKG_SHA256="2d98c599d8bd120e75a9366d4d5c0b1284fee04cfdae4152898e0950544aa8eb"
+PKG_VERSION="4a8ecd77446d8653c99a673e7896f70a4489b1bb"
+PKG_SHA256="aac0b9a1058fa99e7886c2639bd115c6cd40b3828a438abdfd4744af9d88cdb5"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://www.icculus.org/SDL_sound/"
-PKG_URL="http://hg.icculus.org/icculus/SDL_sound/archive/$PKG_VERSION.tar.gz"
+PKG_URL="https://github.com/icculus/SDL_sound/archive/$PKG_VERSION.zip"
 PKG_DEPENDS_TARGET="toolchain alsa-lib SDL2-git"
 PKG_LONGDESC="SDL_sound library"
 PKG_TOOLCHAIN="autotools"


### PR DESCRIPTION
Following the readme on compiling, make fails on this package because it can't find the listed archive on icculus.org
Tracing through github, I found the exact same commit and just replaced the version, sha, and url to point to git rather than icculus.org
make passes this step with these updates
Note that this isn't the latest version available, just the same exact one (if it aint broke dont fix it) from a different host.  There may be a newer version thats 'better'