### PR TITLE
Update run_smw.sh

### DIFF
--- a/packages/sx05re/emuelec-ports/supermariowar/scripts/run_smw.sh
+++ b/packages/sx05re/emuelec-ports/supermariowar/scripts/run_smw.sh
@@ -35,12 +35,12 @@ if [ ! -e "${DATAFOLDER}/worlds/Big JM_Mixed River.txt" ]; then
             rm "imgui.ini" > /dev/tty0 2>&1
             ee_console disable
             cd "${DATAFOLDER}/.."
-            smw "${DATAFOLDER}" > /emuelec/logs/emuelec.log 2>&1
+            smw --datadir "${DATAFOLDER}" > /emuelec/logs/emuelec.log 2>&1
         else
             exit 0
         fi
 else
-    smw "${DATAFOLDER}" > /emuelec/logs/emuelec.log 2>&1
+    smw --datadir "${DATAFOLDER}" > /emuelec/logs/emuelec.log 2>&1
 fi
 
 killall gptokeyb &


### PR DESCRIPTION
As of this commit (https://github.com/mmatyas/supermariowar/commit/85a5b2c81f5ea0cb948414b5033047301559f331) the parameter "--datadir" seems to be necessary.
What is the file "nofakekeyb" good for? gptokeyb ist only started at the first invocation of this script!?!