### PR TITLE
Drastic did not work after update

### DIFF
--- a/packages/sx05re/emuelec/bin/emustation-config
+++ b/packages/sx05re/emuelec/bin/emustation-config
@@ -175,7 +175,6 @@ if [[ "${CVER}" != "${NVER}" ]]; then
     echo "${NVER}" > /storage/.config/EE_VERSION
 (
     if grep -q '<name>nds</name>' "${OLDCFG}"; then
-        EXE="emuelecRunEmu.sh"
         xmlstarlet ed --omit-decl --inplace \
             -s '//systemList' -t elem -n 'system' \
             -s '//systemList/system[last()]' -t elem -n 'name' -v 'nds'\
@@ -185,7 +184,7 @@ if [[ "${CVER}" != "${NVER}" ]]; then
             -s '//systemList/system[last()]' -t elem -n 'hardware' -v 'portable'\
             -s '//systemList/system[last()]' -t elem -n 'path' -v '/storage/roms/nds'\
             -s '//systemList/system[last()]' -t elem -n 'extension' -v '.nds .zip .NDS .ZIP'\
-            -s '//systemList/system[last()]' -t elem -n 'command' -v "$EXE %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers=\"%CONTROLLERSCONFIG%\""\
+            -s '//systemList/system[last()]' -t elem -n 'command' -v "emuelecRunEmu.sh %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers=\"%CONTROLLERSCONFIG%\""\
             -s '//systemList/system[last()]' -t elem -n 'platform' -v 'nds'\
             -s '//systemList/system[last()]' -t elem -n 'theme' -v 'nds'\
             ${CFG} 


### PR DESCRIPTION
After an update the new "es_systems.cfg" is copied and checked if the system "nds" was in place.
If so, the corresponding entry is recreated but there was a missing variable, so that drastic could not be started.