### PR TITLE
Adding cas extension to msx and msx 2 to load cassetes on Emulationstation

### DIFF
--- a/packages/sx05re/emuelec-emulationstation/config/es_systems.cfg
+++ b/packages/sx05re/emuelec-emulationstation/config/es_systems.cfg
@@ -668,7 +668,7 @@ This file will be replaced on any new update of EmuELEC-->
 		<release>1983</release>
 		<hardware>computer</hardware>		
 		<path>/storage/roms/msx</path>
-		<extension>.dsk .DSK .mx1 .MX1 .mx2 .MX2 .rom .ROM .zip .ZIP .7z .7Z .m3u .M3U</extension>
+		<extension>.dsk .DSK .mx1 .MX1 .mx2 .MX2 .rom .ROM .zip .ZIP .7z .7Z .m3u .M3U .cas .CAS</extension>
 		<command>emuelecRunEmu.sh %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers="%CONTROLLERSCONFIG%"</command>
 		<platform>msx</platform>
 		<theme>msx</theme>
@@ -688,7 +688,7 @@ This file will be replaced on any new update of EmuELEC-->
 		<release>1985</release>
 		<hardware>computer</hardware>		
 		<path>/storage/roms/msx2</path>
-		<extension>.dsk .DSK .mx1 .MX1 .mx2 .MX2 .rom .ROM .zip .ZIP .7z .7Z .m3u .M3U</extension>
+		<extension>.dsk .DSK .mx1 .MX1 .mx2 .MX2 .rom .ROM .zip .ZIP .7z .7Z .m3u .M3U .cas .CAS</extension>
 		<command>emuelecRunEmu.sh %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers="%CONTROLLERSCONFIG%"</command>
 		<platform>msx</platform>
 		<theme>msx2</theme>


### PR DESCRIPTION
Added cas extension to es_system.cfg to have cassete support due to Fmsx is supporting it.