### PR TITLE
fix(package): path to duckstation-lr zip file

### DIFF
--- a/packages/sx05re/emulators/duckstation-lr/package.mk
+++ b/packages/sx05re/emulators/duckstation-lr/package.mk
@@ -11,7 +11,7 @@ PKG_SHORTDESC="Fast PlayStation 1 emulator for PC and Android "
 PKG_TOOLCHAIN="manual"
 
 pre_unpack() {
-	unzip sources/duckstation/duckstation-${PKG_VERSION}.zip -d $PKG_BUILD
+	unzip sources/${PKG_NAME}/${PKG_NAME}-${PKG_VERSION}.zip -d $PKG_BUILD
 }
 
 makeinstall_target() {


### PR DESCRIPTION
Solves a copy paste issue. The zip file is expected to be placed into a different directory (`sources/duckstation-lr` instead of `sources/duckstation`).

```
UNPACK      duckstation-lr
unzip:  cannot find or open sources/duckstation/duckstation-f799f62a.zip, sources/duckstation/duckstation-f799f62a.zip.zip or sources/duckstation/duckstation-f799f62a.zip.ZIP.
FAILURE: scripts/unpack duckstation-lr during pre_unpack (package.mk)
```