### PR TITLE
Update es_systems.cfg to include mesen-s in gb,gbc

### DIFF
--- a/packages/sx05re/emuelec-emulationstation/config/es_systems.cfg
+++ b/packages/sx05re/emuelec-emulationstation/config/es_systems.cfg
@@ -1071,6 +1071,7 @@ This file will be replaced on any new update of EmuELEC-->
                     <core>mgba</core>
                     <core>vbam</core>
                     <core>vba_next</core>
+                    <core>mesen-s</core>
                 </cores>
             </emulator>
         </emulators>
@@ -1139,6 +1140,7 @@ This file will be replaced on any new update of EmuELEC-->
                     <core>mgba</core>
                     <core>vbam</core>
                     <core>vba_next</core>
+                    <core>mesen-s</core>
                 </cores>
             </emulator>
         </emulators>
@@ -1163,6 +1165,7 @@ This file will be replaced on any new update of EmuELEC-->
                     <core>mgba</core>
                     <core>vbam</core>
                     <core>vba_next</core>
+                    <core>mesen-s</core>
                 </cores>
             </emulator>
         </emulators>
@@ -1187,6 +1190,7 @@ This file will be replaced on any new update of EmuELEC-->
                     <core>mgba</core>
                     <core>vbam</core>
                     <core>vba_next</core>
+                    <core>mesen-s</core>
                 </cores>
             </emulator>
         </emulators>


### PR DESCRIPTION
Include mesen-s as core in es_systems.cfg for gb, gbh, gbc and gbch.
This will enable Super Game Boy emulation on Amlogic systems.