### PR TITLE
Fix audio stuttering in lzdoom again

### DIFF
--- a/packages/audio/libsndfile/package.mk
+++ b/packages/audio/libsndfile/package.mk
@@ -22,6 +22,7 @@ PKG_CMAKE_OPTS_TARGET="-DBUILD_PROGRAMS=OFF \
                        -DBUILD_EXAMPLES=OFF \
                        -DBUILD_REGTEST=OFF \
                        -DBUILD_TESTING=OFF \
+                       -DBUILD_SHARED_LIBS=ON \
                        -DENABLE_EXTERNAL_LIBS=ON \
                        -DINSTALL_MANPAGES=OFF \
                        -DINSTALL_PKGCONFIG_MODULE=ON"


### PR DESCRIPTION
This bug was already fixed (see https://github.com/EmuELEC/EmuELEC/issues/690) but seems to be re-introduced with the new build system.