### PR TITLE
dev joy advmame fix - 1 controller controlling 2 players and more bug.

### DIFF
--- a/packages/sx05re/emuelec/bin/set_advmame_joy.sh
+++ b/packages/sx05re/emuelec/bin/set_advmame_joy.sh
@@ -121,13 +121,13 @@ set_pad(){
     fi
   fi
 
-  local NAME_NUM="${GC_NAMES[$JOY_NAME]}"
+  local NAME_NUM="${GC_NAMES[$GAMEPAD]}"
   if [[ -z "NAME_NUM" ]]; then
-    GC_NAMES[$JOY_NAME]=1
+    GC_NAMES[$GAMEPAD]=1
   else
-    GC_NAMES[$JOY_NAME]=$(( NAME_NUM+1 ))
+    GC_NAMES[$GAMEPAD]=$(( NAME_NUM+1 ))
   fi
-	[[ "$1" != "1" && "$NAME_NUM" -gt "1" ]] && GAMEPAD="${GAMEPAD}_${NAME_NUM}"
+	[[ "${GC_NAMES[$GAMEPAD]}" -gt "1" ]] && GAMEPAD="${GAMEPAD}_${GC_NAMES[$GAMEPAD]}"
 
   local GC_MAP=$(echo $GC_CONFIG | cut -d',' -f3-)
 


### PR DESCRIPTION
This fixes a bug in that when the controllers are named the same and set in the config, It makes it so the 1st controller cant control both players. Before this change it was causing this issue. These changes fix that issue. Note - This issue is only for advmame too and not any others as advmame has a separate naming convention for controllers in the config.

Tested and working. Should work with other controller names too.
 