### PR TITLE
Update batocera-es-thebezelproject

### DIFF
--- a/packages/sx05re/emuelec/bin/batocera/batocera-es-thebezelproject
+++ b/packages/sx05re/emuelec/bin/batocera/batocera-es-thebezelproject
@@ -246,6 +246,11 @@ esac
 			else
 			EE_REALSYSTEM="GameBezels/${gitsystem}"
 		fi
+    
+    if [ "${systemtoinstall}" == "genesis" ] || [ "${systemtoinstall}" == "megadrive" ]; then
+      # ${gitsystem} has wrong case -- MegaDrive instead of Megadrive
+      EE_REALSYSTEM="GameBezels/Megadrive"
+    fi
 		
 		if [ -f "${tmp}/${gitname}/retroarch/overlay/$EE_REALSYSTEM/${romname}.png" ]; then
 			[ $DEBUG -eq 1 ] && echo "DEBUG: found PNG for ${romname}"


### PR DESCRIPTION
Variable gitsystem pulls the name "MegaDrive" from thebezelproject but the repo uses the lower case "Megadrive" causing a file mismatch error.  This adds an exception to correct the case.