### PR TITLE
fix fs-resize would break on 4GB drives, and EEROMS was not properly formatted on USB drives

### DIFF
--- a/packages/sysutils/busybox/scripts/fs-resize
+++ b/packages/sysutils/busybox/scripts/fs-resize
@@ -25,11 +25,11 @@ if [ -e /storage/.please_resize_me ] ; then
   case $PART in
     "/dev/mmcblk"* | "/dev/nvme"*)
       DISK=$(echo $PART | sed s/p2$//g)
-      ROM_PART_NAME="${DISK}p3"
+      ROMS_PART_NAME="${DISK}p3"
       ;;
     *)
       DISK=$(echo $PART | sed s/2$//g)
-      ROM_PART_NAME="${DISK}3"
+      ROMS_PART_NAME="${DISK}3"
       ;;
   esac
 
@@ -39,6 +39,23 @@ if [ -e /storage/.please_resize_me ] ; then
   # just in case
   if [ ! -z "$DISK" -a ! -z "$PART" ] ; then
     umount $PART
+
+    DISK_NAME=$(basename $DISK)
+    DISK_SECTORS=$(cat "/sys/block/$DISK_NAME/size") # Obtain the disk sectors count, each sector is always 512 Bytes large, independent of the underlying device, according to https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/types.h#n117
+    DISK_SIZE=$(( $DISK_SECTORS * 512 )) # Calculate the disk actual size, in byte
+    if [ $DISK_SIZE -gt 4294967296 ]; then # The optimal behaviour, this will leave 2GiB to storage, and create the EEROMS partition
+      ROMS_CREATE='yes'
+      STORAGE_END='4GiB'
+    elif [ $DISK_SIZE -gt 3221225472 ]; then  # Optionaly omit the EEROMS partition for 4GB cards/drives
+      ROMS_CREATE=''
+      STORAGE_END='100%'
+    else
+      # The bare minumum a EmuELEC image itself needs is 2186280960, but after adding in user configs things become uncontrollable, so we don't care about disks with size between 2085MiB and 3GiB
+      echo 'ERROR: You disk is too small! You need to use a USB drive/SD card that is at least 4GB!'
+      echo 'ERROR: You should NOT try to boot up this drive as it is NOT properly resized!'
+      StartProgress countdown "Powering off in 30s...     " 30 "NOW"
+      poweroff
+    fi
 
     echo "PARTITION RESIZING IN PROGRESS"
     echo ""
@@ -78,43 +95,31 @@ if [ -e /storage/.please_resize_me ] ; then
       ;;
       esac    
       
-    fi 
-
-    DISK_NAME=$(basename $DISK)
-    DISK_SECTORS=$(cat "/sys/block/$DISK_NAME/size") # Obtain the disk sectors count, each sector is always 512 Bytes large, independent of the underlying device, according to https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/types.h#n117
-    DISK_SIZE=$(( $DISK_SECTORS * 512 )) # Calculate the disk actual size, in byte
-    if [ $DISK_SIZE -gt 4294967296 ]; then # The default behaviour that EmuELEC used to have, this will leave 2GiB to storage
-      ROMS_OFFSET='4GiB'
-    elif [ $DISK_SIZE -gt 3221225472 ]; then  # Optionaly reduce the eeroms offset if disk is too small (larger than 2GiB since the image was written successfully anyway, smaller than 4GiB as many cheapo 4GB cards are smaller than 4GiB, this is mainly for 4GB SD cards/USB drive)
-      ROMS_OFFSET='3GiB'
-    else
-      # The bare minumum a EmuELEC image itself needs is 2186280960, but after adding in user configs things become uncontrollable, so we don't care about disks with size between 2085MiB and 3GiB
-      echo 'ERROR: You disk is too small! You need to use a USB drive/SD card that is at least 4GB!'
-      echo 'ERROR: You should NOT try to boot up this drive as it is NOT properly resized!'
-      StartProgress countdown "Powering off in 30s...     " 30 "NOW"
-      poweroff
     fi
-    StartProgress spinner "Resizing partition...   " "parted -s -a optimal -m $DISK resizepart 2 $ROMS_OFFSET &>/dev/null"
+
+    StartProgress spinner "Resizing partition...   " "parted -s -a optimal -m $DISK resizepart 2 $STORAGE_END &>/dev/null"
     StartProgress spinner "Checking file system... " "e2fsck -f -p $PART &>/dev/null"
     StartProgress spinner "Resizing file system... " "resize2fs $PART &>/dev/null"
-    StartProgress spinner "Creating EEROMS partition..." "parted -s -a optimal -m $DISK mkpart primary ${PARTED_FS_TYPE} $ROMS_OFFSET 100% &>/dev/null"
-    partprobe &>/dev/null
-        
-    case $ROM_FS_TYPE in 
-      "ntfs")
-      StartProgress spinner "Formatting EEROMS partition as NTFS..." "mkfs.ntfs -L EEROMS -f ${ROM_PART_NAME} &>/dev/null"
-      ;;
-      "ext4")
-      StartProgress spinner "Formatting EEROMS partition as EXT4..." "mkfs.ext4 -L EEROMS -t ext4 -O 64bit ${ROM_PART_NAME} &>/dev/null"
-      ;;
-      "exfat")
-      StartProgress spinner "Formatting EEROMS partition as EXFAT..." "mkfs.exfat -n EEROMS ${ROM_PART_NAME} &>/dev/null"
-      ;;
-      *)
-      StartProgress spinner "Formatting EEROMS partition as FAT32..." "mkfs.vfat -n EEROMS ${ROM_PART_NAME} &>/dev/null"
-      ;;
-    esac    
-
+    if [ "$ROMS_CREATE" ]; then
+      StartProgress spinner "Creating EEROMS partition..." "parted -s -a optimal -m $DISK mkpart primary ${PARTED_FS_TYPE} 4GiB 100% &>/dev/null"
+      partprobe &>/dev/null
+      case $ROM_FS_TYPE in 
+        "ntfs")
+        StartProgress spinner "Formatting EEROMS partition as NTFS..." "mkfs.ntfs -L EEROMS -f ${ROMS_PART_NAME} &>/dev/null"
+        ;;
+        "ext4")
+        StartProgress spinner "Formatting EEROMS partition as EXT4..." "mkfs.ext4 -L EEROMS -t ext4 -O 64bit ${ROMS_PART_NAME} &>/dev/null"
+        ;;
+        "exfat")
+        StartProgress spinner "Formatting EEROMS partition as EXFAT..." "mkfs.exfat -n EEROMS ${ROMS_PART_NAME} &>/dev/null"
+        ;;
+        *)
+        StartProgress spinner "Formatting EEROMS partition as FAT32..." "mkfs.vfat -n EEROMS ${ROMS_PART_NAME} &>/dev/null"
+        ;;
+      esac   
+    else
+      echo 'WARNING: EEROMS partition is omitted for 4GB drives'
+    fi
     StartProgress countdown "Rebooting in 5s...     " 5 "NOW"
   fi
 fi

--- a/packages/sysutils/busybox/scripts/fs-resize
+++ b/packages/sysutils/busybox/scripts/fs-resize
@@ -56,30 +56,30 @@ if [ -e /storage/.please_resize_me ] ; then
     PARTED_FS_TYPE="fat32"
 
     if [ -e "/flash/ee_fstype" ]; then
-        EE_FS_TYPE=$(cat "/flash/ee_fstype")
-        
-        case $EE_FS_TYPE in
-        "ntfs")
-            ROM_FS_TYPE="ntfs"
-            PARTED_FS_TYPE="ntfs"
-        ;;
-        "ext4")
-            ROM_FS_TYPE="ext4"
-            PARTED_FS_TYPE="ext4"
-        ;;
-        "exfat")
-            ROM_FS_TYPE="exfat"
-            PARTED_FS_TYPE="ntfs"
-        ;;
-        *)
-            # Failsafe
-            ROM_FS_TYPE="vfat"
-            PARTED_FS_TYPE="fat32"
-        ;;
-        esac    
+      EE_FS_TYPE=$(cat "/flash/ee_fstype")
+      
+      case $EE_FS_TYPE in
+      "ntfs")
+          ROM_FS_TYPE="ntfs"
+          PARTED_FS_TYPE="ntfs"
+      ;;
+      "ext4")
+          ROM_FS_TYPE="ext4"
+          PARTED_FS_TYPE="ext4"
+      ;;
+      "exfat")
+          ROM_FS_TYPE="exfat"
+          PARTED_FS_TYPE="ntfs"
+      ;;
+      *)
+          # Failsafe
+          ROM_FS_TYPE="vfat"
+          PARTED_FS_TYPE="fat32"
+      ;;
+      esac    
       
     fi 
-    
+
     DISK_NAME=$(basename $DISK)
     DISK_SECTORS=$(cat "/sys/block/$DISK_NAME/size") # Obtain the disk sectors count, each sector is always 512 Bytes large, independent of the underlying device, according to https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/types.h#n117
     DISK_SIZE=$(( $DISK_SECTORS * 512 )) # Calculate the disk actual size, in byte
@@ -101,18 +101,18 @@ if [ -e /storage/.please_resize_me ] ; then
     partprobe &>/dev/null
         
     case $ROM_FS_TYPE in 
-        "ntfs")
-        StartProgress spinner "Formatting EEROMS partition as NTFS..." "mkfs.ntfs -L EEROMS -f ${ROM_PART_NAME} &>/dev/null"
-        ;;
-        "ext4")
-        StartProgress spinner "Formatting EEROMS partition as EXT4..." "mkfs.ext4 -L EEROMS -t ext4 -O 64bit ${ROM_PART_NAME} &>/dev/null"
-        ;;
-        "exfat")
-        StartProgress spinner "Formatting EEROMS partition as EXFAT..." "mkfs.exfat -n EEROMS ${ROM_PART_NAME} &>/dev/null"
-        ;;
-        *)
-        StartProgress spinner "Formatting EEROMS partition as FAT32..." "mkfs.vfat -n EEROMS ${ROM_PART_NAME} &>/dev/null"
-        ;;
+      "ntfs")
+      StartProgress spinner "Formatting EEROMS partition as NTFS..." "mkfs.ntfs -L EEROMS -f ${ROM_PART_NAME} &>/dev/null"
+      ;;
+      "ext4")
+      StartProgress spinner "Formatting EEROMS partition as EXT4..." "mkfs.ext4 -L EEROMS -t ext4 -O 64bit ${ROM_PART_NAME} &>/dev/null"
+      ;;
+      "exfat")
+      StartProgress spinner "Formatting EEROMS partition as EXFAT..." "mkfs.exfat -n EEROMS ${ROM_PART_NAME} &>/dev/null"
+      ;;
+      *)
+      StartProgress spinner "Formatting EEROMS partition as FAT32..." "mkfs.vfat -n EEROMS ${ROM_PART_NAME} &>/dev/null"
+      ;;
     esac    
 
     StartProgress countdown "Rebooting in 5s...     " 5 "NOW"

--- a/packages/sysutils/busybox/scripts/fs-resize
+++ b/packages/sysutils/busybox/scripts/fs-resize
@@ -25,9 +25,11 @@ if [ -e /storage/.please_resize_me ] ; then
   case $PART in
     "/dev/mmcblk"* | "/dev/nvme"*)
       DISK=$(echo $PART | sed s/p2$//g)
+      ROM_PART_NAME="${DISK}p3"
       ;;
     *)
       DISK=$(echo $PART | sed s/2$//g)
+      ROM_PART_NAME="${DISK}3"
       ;;
   esac
 
@@ -77,24 +79,38 @@ if [ -e "/flash/ee_fstype" ]; then
     esac    
    
 fi 
-    StartProgress spinner "Resizing partition...   " "parted -s -a optimal -m $DISK resizepart 2 4GiB &>/dev/null"
+    DISK_NAME=$(basename $DISK)
+    DISK_SECTORS=$(cat "/sys/block/$DISK_NAME/size") # Obtain the disk sector
+    SECTOR_SIZE=$(cat "/sys/block/$DISK_NAME/queue/physical_block_size") # Obtain the sector size, in most situations this should be 512, but there ARE exceptions
+    DISK_SIZE=$(( $DISK_SECTORS * $SECTOR_SIZE )) # Calculate the disk actual size, in byte
+    if [ $DISK_SIZE -gt 4294967296 ]; then # The default behaviour that EmuELEC used to have
+      ROMS_OFFSET='4GiB'
+    elif [ $DISK_SIZE -gt 3221225472 ]; then  # Optionaly reduce the roms offset if disk is too small (larger than 2GiB since the image was written anyway, smaller than 4GiB as many cheapo 4GB cards are smaller than 4GiB, this is mainly for 4GB SD cards/USB drive)
+      ROMS_OFFSET='3GiB'
+    else
+      # The bare minumum a EmuELEC image itself needs is 2186280960, but after adding in user configs things become uncontrollable, so we don't care about disks with size between 2085MiB and 3GiB
+      echo 'ERROR: You disk is too smaller! You need to use a USB drive/SD card that is at least 4GB.'
+      StartProgress countdown "Powering off in 30s...     " 30 "NOW"
+      poweroff
+    fi
+    StartProgress spinner "Resizing partition...   " "parted -s -a optimal -m $DISK resizepart 2 $ROMS_OFFSET &>/dev/null"
     StartProgress spinner "Checking file system... " "e2fsck -f -p $PART &>/dev/null"
     StartProgress spinner "Resizing file system... " "resize2fs $PART &>/dev/null"
-    StartProgress spinner "Creating EEROMS partition..." "parted -s -a optimal -m $DISK mkpart primary ${PARTED_FS_TYPE} 4296MB 100% &>/dev/null"
+    StartProgress spinner "Creating EEROMS partition..." "parted -s -a optimal -m $DISK mkpart primary ${PARTED_FS_TYPE} $ROMS_OFFSET 100% &>/dev/null"
     partprobe &>/dev/null
     
 case $ROM_FS_TYPE in 
     "ntfs")
-    StartProgress spinner "Formatting EEROMS partition as NTFS..." "mkfs.ntfs -L EEROMS -f ${DISK}p3 &>/dev/null"
+    StartProgress spinner "Formatting EEROMS partition as NTFS..." "mkfs.ntfs -L EEROMS -f ${ROM_PART_NAME} &>/dev/null"
     ;;
     "ext4")
-    StartProgress spinner "Formatting EEROMS partition as EXT4..." "mkfs.ext4 -L EEROMS -t ext4 -O 64bit ${DISK}p3 &>/dev/null"
+    StartProgress spinner "Formatting EEROMS partition as EXT4..." "mkfs.ext4 -L EEROMS -t ext4 -O 64bit ${ROM_PART_NAME} &>/dev/null"
     ;;
     "exfat")
-    StartProgress spinner "Formatting EEROMS partition as EXFAT..." "mkfs.exfat -n EEROMS ${DISK}p3 &>/dev/null"
+    StartProgress spinner "Formatting EEROMS partition as EXFAT..." "mkfs.exfat -n EEROMS ${ROM_PART_NAME} &>/dev/null"
     ;;
     *)
-    StartProgress spinner "Formatting EEROMS partition as FAT32..." "mkfs.vfat -n EEROMS ${DISK}p3 &>/dev/null"
+    StartProgress spinner "Formatting EEROMS partition as FAT32..." "mkfs.vfat -n EEROMS ${ROM_PART_NAME} &>/dev/null"
     ;;
 esac    
 

--- a/packages/sysutils/busybox/scripts/fs-resize
+++ b/packages/sysutils/busybox/scripts/fs-resize
@@ -51,34 +51,35 @@ if [ -e /storage/.please_resize_me ] ; then
       StartProgress spinner "Checking layout...      " "sgdisk -e $DISK &>/dev/null"
     fi
     
-# EmueELEC Get EEROMS filetype
-ROM_FS_TYPE="vfat"
-PARTED_FS_TYPE="fat32"
+    # EmueELEC Get EEROMS filetype
+    ROM_FS_TYPE="vfat"
+    PARTED_FS_TYPE="fat32"
 
-if [ -e "/flash/ee_fstype" ]; then
-    EE_FS_TYPE=$(cat "/flash/ee_fstype")
+    if [ -e "/flash/ee_fstype" ]; then
+        EE_FS_TYPE=$(cat "/flash/ee_fstype")
+        
+        case $EE_FS_TYPE in
+        "ntfs")
+            ROM_FS_TYPE="ntfs"
+            PARTED_FS_TYPE="ntfs"
+        ;;
+        "ext4")
+            ROM_FS_TYPE="ext4"
+            PARTED_FS_TYPE="ext4"
+        ;;
+        "exfat")
+            ROM_FS_TYPE="exfat"
+            PARTED_FS_TYPE="ntfs"
+        ;;
+        *)
+            # Failsafe
+            ROM_FS_TYPE="vfat"
+            PARTED_FS_TYPE="fat32"
+        ;;
+        esac    
+      
+    fi 
     
-    case $EE_FS_TYPE in
-    "ntfs")
-        ROM_FS_TYPE="ntfs"
-        PARTED_FS_TYPE="ntfs"
-    ;;
-    "ext4")
-        ROM_FS_TYPE="ext4"
-        PARTED_FS_TYPE="ext4"
-    ;;
-    "exfat")
-        ROM_FS_TYPE="exfat"
-        PARTED_FS_TYPE="ntfs"
-    ;;
-    *)
-        # Failsafe
-        ROM_FS_TYPE="vfat"
-        PARTED_FS_TYPE="fat32"
-    ;;
-    esac    
-   
-fi 
     DISK_NAME=$(basename $DISK)
     DISK_SECTORS=$(cat "/sys/block/$DISK_NAME/size") # Obtain the disk sectors count, each sector is always 512 Bytes large, independent of the underlying device, according to https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/types.h#n117
     DISK_SIZE=$(( $DISK_SECTORS * 512 )) # Calculate the disk actual size, in byte
@@ -98,21 +99,21 @@ fi
     StartProgress spinner "Resizing file system... " "resize2fs $PART &>/dev/null"
     StartProgress spinner "Creating EEROMS partition..." "parted -s -a optimal -m $DISK mkpart primary ${PARTED_FS_TYPE} $ROMS_OFFSET 100% &>/dev/null"
     partprobe &>/dev/null
-    
-case $ROM_FS_TYPE in 
-    "ntfs")
-    StartProgress spinner "Formatting EEROMS partition as NTFS..." "mkfs.ntfs -L EEROMS -f ${ROM_PART_NAME} &>/dev/null"
-    ;;
-    "ext4")
-    StartProgress spinner "Formatting EEROMS partition as EXT4..." "mkfs.ext4 -L EEROMS -t ext4 -O 64bit ${ROM_PART_NAME} &>/dev/null"
-    ;;
-    "exfat")
-    StartProgress spinner "Formatting EEROMS partition as EXFAT..." "mkfs.exfat -n EEROMS ${ROM_PART_NAME} &>/dev/null"
-    ;;
-    *)
-    StartProgress spinner "Formatting EEROMS partition as FAT32..." "mkfs.vfat -n EEROMS ${ROM_PART_NAME} &>/dev/null"
-    ;;
-esac    
+        
+    case $ROM_FS_TYPE in 
+        "ntfs")
+        StartProgress spinner "Formatting EEROMS partition as NTFS..." "mkfs.ntfs -L EEROMS -f ${ROM_PART_NAME} &>/dev/null"
+        ;;
+        "ext4")
+        StartProgress spinner "Formatting EEROMS partition as EXT4..." "mkfs.ext4 -L EEROMS -t ext4 -O 64bit ${ROM_PART_NAME} &>/dev/null"
+        ;;
+        "exfat")
+        StartProgress spinner "Formatting EEROMS partition as EXFAT..." "mkfs.exfat -n EEROMS ${ROM_PART_NAME} &>/dev/null"
+        ;;
+        *)
+        StartProgress spinner "Formatting EEROMS partition as FAT32..." "mkfs.vfat -n EEROMS ${ROM_PART_NAME} &>/dev/null"
+        ;;
+    esac    
 
     StartProgress countdown "Rebooting in 5s...     " 5 "NOW"
   fi

--- a/packages/sysutils/busybox/scripts/fs-resize
+++ b/packages/sysutils/busybox/scripts/fs-resize
@@ -80,16 +80,17 @@ if [ -e "/flash/ee_fstype" ]; then
    
 fi 
     DISK_NAME=$(basename $DISK)
-    DISK_SECTORS=$(cat "/sys/block/$DISK_NAME/size") # Obtain the disk sector
+    DISK_SECTORS=$(cat "/sys/block/$DISK_NAME/size") # Obtain the disk sectors count
     SECTOR_SIZE=$(cat "/sys/block/$DISK_NAME/queue/physical_block_size") # Obtain the sector size, in most situations this should be 512, but there ARE exceptions
     DISK_SIZE=$(( $DISK_SECTORS * $SECTOR_SIZE )) # Calculate the disk actual size, in byte
-    if [ $DISK_SIZE -gt 4294967296 ]; then # The default behaviour that EmuELEC used to have
+    if [ $DISK_SIZE -gt 4294967296 ]; then # The default behaviour that EmuELEC used to have, this will leave 2GiB to storage
       ROMS_OFFSET='4GiB'
-    elif [ $DISK_SIZE -gt 3221225472 ]; then  # Optionaly reduce the roms offset if disk is too small (larger than 2GiB since the image was written anyway, smaller than 4GiB as many cheapo 4GB cards are smaller than 4GiB, this is mainly for 4GB SD cards/USB drive)
+    elif [ $DISK_SIZE -gt 3221225472 ]; then  # Optionaly reduce the eeroms offset if disk is too small (larger than 2GiB since the image was written successfully anyway, smaller than 4GiB as many cheapo 4GB cards are smaller than 4GiB, this is mainly for 4GB SD cards/USB drive)
       ROMS_OFFSET='3GiB'
     else
       # The bare minumum a EmuELEC image itself needs is 2186280960, but after adding in user configs things become uncontrollable, so we don't care about disks with size between 2085MiB and 3GiB
-      echo 'ERROR: You disk is too smaller! You need to use a USB drive/SD card that is at least 4GB.'
+      echo 'ERROR: You disk is too small! You need to use a USB drive/SD card that is at least 4GB!'
+      echo 'ERROR: You should NOT try to boot up this drive as it is NOT properly resized!'
       StartProgress countdown "Powering off in 30s...     " 30 "NOW"
       poweroff
     fi

--- a/packages/sysutils/busybox/scripts/fs-resize
+++ b/packages/sysutils/busybox/scripts/fs-resize
@@ -80,9 +80,8 @@ if [ -e "/flash/ee_fstype" ]; then
    
 fi 
     DISK_NAME=$(basename $DISK)
-    DISK_SECTORS=$(cat "/sys/block/$DISK_NAME/size") # Obtain the disk sectors count
-    SECTOR_SIZE=$(cat "/sys/block/$DISK_NAME/queue/physical_block_size") # Obtain the sector size, in most situations this should be 512, but there ARE exceptions
-    DISK_SIZE=$(( $DISK_SECTORS * $SECTOR_SIZE )) # Calculate the disk actual size, in byte
+    DISK_SECTORS=$(cat "/sys/block/$DISK_NAME/size") # Obtain the disk sectors count, each sector is always 512 Bytes large, independent of the underlying device, according to https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/types.h#n117
+    DISK_SIZE=$(( $DISK_SECTORS * 512 )) # Calculate the disk actual size, in byte
     if [ $DISK_SIZE -gt 4294967296 ]; then # The default behaviour that EmuELEC used to have, this will leave 2GiB to storage
       ROMS_OFFSET='4GiB'
     elif [ $DISK_SIZE -gt 3221225472 ]; then  # Optionaly reduce the eeroms offset if disk is too small (larger than 2GiB since the image was written successfully anyway, smaller than 4GiB as many cheapo 4GB cards are smaller than 4GiB, this is mainly for 4GB SD cards/USB drive)


### PR DESCRIPTION
Previously the 2nd partition (*storage*) was resized to end at **4GiB**, and the 3rd partition (*eeroms*) will be created from 4GiB to fit the whole disk.

On most **4GB** SD cards/USB drives though this will **fail**, since they're actually **smaller** than 4GiB, when parted was issued to resize the 2nd partition to end at 4GiB the part **overflows** and parted **will errored out**. The 3rd partition also won't be created.

After booting up, as the storage partition is only **32M** as a result of failed fs-resizing, users will be **locked out at the splash screen**. They are not even possible to see any error message as the SSH host key init will **fail and restart over and over** as disk space is **userd up** and stop any systemd log from showing up.

This fixes that by calculating the size of the disk first, then reducing the roms offset if the disk size is **smaller** than 4GiB, and further refusing to resize and create the 3rd partition if the disk size is to small, i.e. smaller than **3GiB** (*Since you are not even possible to flash EmuELEC image to 2GB disks, and 4GB disks won't be watered down to 3GiB anyway*), Considering after userconfig-setup and usercache-setup around **0.5GB** of the storage partition will be taken, this should be safe.

Also the 3rd partition name used to be **DISK**p3, and if you are booting EmuELEC from USB drive this is should be **DISK**3 instead, so mkfs.whatever **DISK**p3 would fail as there is no such partition, it is also fixed now by obtaining the name first depending on the type of the drive