### PR TITLE
ampart: bump to 31216c5, ampart/aminstall: fix roms migration with two possibilities of EEROMS' existence

### DIFF
--- a/projects/Amlogic-ce/packages/tools/ampart/aminstall
+++ b/projects/Amlogic-ce/packages/tools/ampart/aminstall
@@ -436,7 +436,7 @@ populate_storage() {
   fi
   if [ "$EMPTY" ]; then
     printf "Do you want to copy your user data under $DIR_STORAGE to internal $PART_STORAGE_NAME partition? "
-    [ "$ACTION_CREATE_ROMS" ] && printf "(This will not include all of the stuffs under $DIR_ROMS, they will be copied to $PART_ROMS_NAME partition later) "
+    [[ "$ACTION_CREATE_ROMS" || "$ACTION_UPDATE_ROMS" ]] && printf "(This will not include all of the stuffs under $DIR_ROMS, they will be copied to $PART_ROMS_NAME partition later) "
     read -p '[Y/n] ' CHOICE
     if [[ "$CHOICE" =~ ^[nN] ]]; then
       :
@@ -444,7 +444,11 @@ populate_storage() {
       echo "Stopping EmulationStation so we can make sure configs are flushed onto disk... You can run 'systemctl start emustation.service' later to bring EmulationStation back up"
       systemctl stop emustation.service
       echo "Copying user data..."
-      rsync -qaHSx "$DIR_STORAGE/". "$DIR_CACHE"
+      if [[ "$ACTION_CREATE_ROMS" || "$ACTION_UPDATE_ROMS" ]]; then
+        rsync -qaHSx --exclude="$DIR_ROMS/*" "$DIR_STORAGE/". "$DIR_CACHE"
+      else
+        rsync -qaHSx "$DIR_STORAGE/". "$DIR_CACHE"
+      fi
       if [[ -z "$ACTION_CREATE_ROMS" && -z "$ACTION_UPDATE_ROMS" ]]; then
         if grep -qs " $DIR_ROMS " /proc/mounts; then 
           mkdir -p "$DIR_CACHE/roms"

--- a/projects/Amlogic-ce/packages/tools/ampart/aminstall
+++ b/projects/Amlogic-ce/packages/tools/ampart/aminstall
@@ -34,7 +34,8 @@ PART_ROMS_NAME='EEROMS'
 
 DIR_SYSTEM='/flash'
 DIR_STORAGE='/storage'
-DIR_ROMS="$DIR_STORAGE/roms"
+DIR_ROMS_NAME='roms'
+DIR_ROMS="$DIR_STORAGE/$DIR_ROMS_NAME"
 
 PART_SYSTEM_SIZE=$(( 2 * $SIZE_1G ))
 PART_SYSTEM_SIZE_HUMAN='2G'   # This is not used in any processing, just for reporting to users
@@ -445,14 +446,14 @@ populate_storage() {
       systemctl stop emustation.service
       echo "Copying user data..."
       if [[ "$ACTION_CREATE_ROMS" || "$ACTION_UPDATE_ROMS" ]]; then
-        rsync -qaHSx --exclude="$DIR_ROMS/*" "$DIR_STORAGE/". "$DIR_CACHE"
+        rsync -qaHSx --exclude="$DIR_ROMS_NAME/*" "$DIR_STORAGE/". "$DIR_CACHE"
       else
         rsync -qaHSx "$DIR_STORAGE/". "$DIR_CACHE"
       fi
       if [[ -z "$ACTION_CREATE_ROMS" && -z "$ACTION_UPDATE_ROMS" ]]; then
         if grep -qs " $DIR_ROMS " /proc/mounts; then 
-          mkdir -p "$DIR_CACHE/roms"
-          rsync -qaHSx "$DIR_ROMS/". "$DIR_CACHE/roms"
+          mkdir -p "$DIR_CACHE/$DIR_ROMS_NAME"
+          rsync -qaHSx "$DIR_ROMS/". "$DIR_CACHE/$DIR_ROMS_NAME"
         fi
       fi
       sync

--- a/projects/Amlogic-ce/packages/tools/ampart/aminstall
+++ b/projects/Amlogic-ce/packages/tools/ampart/aminstall
@@ -245,7 +245,7 @@ update_table() {
       else
         echo "Oh no! You emmc is smaller than 4G! This is impossible!"
         echo "Every Amlogic S9xxx device should have at least 4G emmc onboard!"
-        echo "I'm afraid you can not install EmuELEC to internal storage :("
+        echo "I'm afraid you can not install $DISTRO_NAME to internal storage :("
         echo "As this only works on emmc at least 4G :<"
         exit 1
       fi
@@ -349,7 +349,7 @@ notice_populate_start() {
   echo "Populating internal $PART_NAME partition..."
 }
 notice_populate_end() {
-  echo "Populated internal $PART_NAME partition..."
+  echo "Populated internal $PART_NAME partition"
 }
 notice_format() {
   echo "Formatting internal $PART_NAME partition..."
@@ -445,6 +445,12 @@ populate_storage() {
       systemctl stop emustation.service
       echo "Copying user data..."
       rsync -qaHSx "$DIR_STORAGE/". "$DIR_CACHE"
+      if [[ -z "$ACTION_CREATE_ROMS" && -z "$ACTION_UPDATE_ROMS" ]]; then
+        if grep -qs " $DIR_ROMS " /proc/mounts; then 
+          mkdir -p "$DIR_CACHE/roms"
+          rsync -qaHSx "$DIR_ROMS/". "$DIR_CACHE/roms"
+        fi
+      fi
       sync
     fi
   fi
@@ -584,7 +590,7 @@ confirm_method() {
       echo "(reserved partitions like bootloader, reserved, env, logo and misc will be kept)"
       echo "You Android installation will be COMPLETELY erased and can not be recovered"
       echo "Unless you use Amlogic USB Burning Tool to flash a stock image"
-      echo "This script will install EmuELEC that you booted from SD card/USB drive."
+      echo "This script will install $DISTRO_NAME that you booted from SD card/USB drive."
       ACTION_SINGLE_BOOT='yes'
       ;;
     '--revert')
@@ -617,10 +623,11 @@ confirm_method() {
 
 regret_pill() {
   echo "Warning: from this point onward, all of the changes are IRREVERSIBLE since new data will be written to emmc. Make sure you keep the power pluged in."
-  echo "If anything breaks apart, you can revert your partition table with the following command, but changes to the data are IRREVERSIBLE"
+  echo "If anything breaks apart, you can revert your partition table and ONLY your partition table with the following command to what it looks like before this run of aminstall, but changes to the data are IRREVERSIBLE"
   echo
   echo "ampart --clone $DISK_DEVICE_PATH $SNAPSHOT_HUMAN"
   echo
+  echo "Please take a note of the above command on your PC/notebooks/any paper in case you mistakenly closed the SSH/Serial client and couldn't find it in the history"
 }
 main() {
   no_coreelec
@@ -632,7 +639,9 @@ main() {
   snapshot
   check_parts
   if [[ -z "$ACTION_SINGLE_BOOT_OLDSCHOOL" && -z "$ACTION_UPDATE" ]]; then
+    echo "Updating partition table on emmc... Please keep the box powered on, interruption during this session will be fatal and will most likely brick your device"
     update_table
+    echo "Partition table updated on emmc"
   fi
   regret_pill
   install_to_internal

--- a/projects/Amlogic-ce/packages/tools/ampart/package.mk
+++ b/projects/Amlogic-ce/packages/tools/ampart/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present 7Ji (pugokushin@gmail.com)
 
 PKG_NAME="ampart"
-PKG_VERSION="7ddfc2a4d1adf1fe8cc9b3774a9cd9f0386e6deb"
-PKG_SHA256="7504bfa2da7a4e42039afea60519cac3ab6c84f4373722efd19969e1906cf785"
+PKG_VERSION="31216c53703d477fd8ace9b03c81528375a0d39f"
+PKG_SHA256="dd54cab3ef176bbc2efb4328e247b3bd1823b650420524f68f7400baac31bc3d"
 PKG_LICENSE="GPL3"
 PKG_SITE="https://github.com/7Ji/ampart"
 PKG_URL="$PKG_SITE/archive/$PKG_VERSION.tar.gz"


### PR DESCRIPTION
This fixes the issue that gzipped dtb wasn't properly modified to remove partitions node to avoid partition table being reverted (some I/O mistake, read something not actually written)

The checksum of both dtbs are also now correctly generated and u-boot won't complain about invalid dtb any more (when both dtbs are invalid, u-boot would still use the first "invalid" one, ampart used to exploit this due to my laziness, but now a dtb-checksum algorithm is implemented)

Both ampart itself and aminstall were tested thoroughly on my one and only -ng capable box BesTV R3300L (gxl-p212) and can't be tested on other devices due to this. U-boot on this box also did not complain about the dtb checksum when I force a  S905X3 dtb extracted from a reserved partition dump ampart has modified (Surely it can't use these dtbs, so I can't make sure the partitions-node-removal function work on real S905X3 hardware), so I guess this also works on S905X3 boxes.