### PR TITLE
mount_romfs.sh: ensure /storage/.update is always mounted as long as EEROMS is valid; mount EEROMS when user-defined storage-roms.mount failed

### DIFF
--- a/packages/sx05re/emuelec/bin/mount_romfs.sh
+++ b/packages/sx05re/emuelec/bin/mount_romfs.sh
@@ -261,7 +261,10 @@ prepare_scan() {
 }
 
 ensure_dir_update_mounted() {
-  mkdir -p "$UPDATE_DIR" &>/dev/null
+  if [[ -L "$UPDATE_DIR" || ! -d "$UPDATE_DIR" ]]; then
+    rm -rf "$UPDATE_DIR" &>/dev/null
+    mkdir -p "$UPDATE_DIR" &>/dev/null
+  fi
   # This should only be useful for the very first boot after a user re-format EEROMS yet forgot to update ee_fstype
   if [ "$BOOL_EEROMS_EXIST" ]  && ! mountpoint -q "$UPDATE_DIR" &>/dev/null; then
     if [ -z "$ROMS_PART_MOUNTPOINT" ]; then

--- a/packages/sx05re/emuelec/bin/mount_romfs.sh
+++ b/packages/sx05re/emuelec/bin/mount_romfs.sh
@@ -392,11 +392,12 @@ if [ "$BOOL_EEROMS_EXIST" ]  && ! mountpoint -q "$UPDATE_DIR" &>/dev/null; then
   else
     BOOL_ROMS_TEMP=''
   fi
-  if [[ -L "$ROMS_PART_MOUNTPOINT" || ! -d "$ROMS_PART_MOUNTPOINT" ]]; then
-    rm -rf "$ROMS_PART_MOUNTPOINT/.update" &>/dev/null
-    mkdir -p "$ROMS_PART_MOUNTPOINT/.update" &>/dev/null
+  ROMS_DIR_UPDATE="$ROMS_PART_MOUNTPOINT/.update"
+  if [[ -L "$ROMS_DIR_UPDATE" || ! -d "$ROMS_DIR_UPDATE" ]]; then
+    rm -rf "$ROMS_DIR_UPDATE" &>/dev/null
+    mkdir -p "$ROMS_DIR_UPDATE" &>/dev/null
   fi
-  mount --bind "$ROMS_PART_MOUNTPOINT/.update" "$UPDATE_DIR" &>/dev/null
+  mount --bind "$ROMS_DIR_UPDATE" "$UPDATE_DIR" &>/dev/null
   if [ "$BOOL_ROMS_TEMP" ]; then
     umount_recursively "$ROMS_PART_MOUNTPOINT"
     rm -rf "$ROMS_PART_MOUNTPOINT" &>/dev/null

--- a/packages/sx05re/emuelec/bin/mount_romfs.sh
+++ b/packages/sx05re/emuelec/bin/mount_romfs.sh
@@ -383,6 +383,7 @@ fi
 
 find "$ROMS_DIR_BACKUP" -maxdepth 0 -empty -exec rm -rf \{} \;
 
+mkdir -p "$UPDATE_DIR" &>/dev/null
 # This should only be useful for the very first boot after a user re-format EEROMS yet forgot to update ee_fstype
 if [ "$BOOL_EEROMS_EXIST" ]  && ! mountpoint -q "$UPDATE_DIR" &>/dev/null; then
   if [ -z "$ROMS_PART_MOUNTPOINT" ]; then


### PR DESCRIPTION
With this fix it's now possible to just re-format the EEROMS partition to any of the supported fs without updating ``ee_fstype`` in EMUELEC partition at all.

As long as EEROMS partition exists and is valid, the script will always try to bind-mount /storage/.update from .update subdir under EEROMS partition if it isn't mounted yet, after scanning. So update dir always points to the same underlying folder as the one would be used during init. 

This means /storage/.update in userspace for the first boot after users re-formatting EEROMS without updating ee_fstype and in init for the next boots is guaranteed to be the same. Therefore update won't be broken due to /storage/.update not correctly bind-mounted after a reformatting without updating ee_fstype.

This also introduces a minor fix that'll try mount /storage/roms from EEROMS when a user-defined storage-roms.mount failed.

Tested on my S905L box and S905X4 box