### PR TITLE
poppler: bump version 32fa288 (22.06.0) and deps fix

### DIFF
--- a/packages/sx05re/tools/sysutils/poppler/package.mk
+++ b/packages/sx05re/tools/sysutils/poppler/package.mk
@@ -2,17 +2,18 @@
 # Copyright (C) 2019-present Shanti Gilbert (https://github.com/shantigilbert)
 
 PKG_NAME="poppler"
-PKG_VERSION="3b82fb789116c805b0a69f6bf3a72466a1e87308"
+PKG_VERSION="32fa2888eaaaaf80e5d2338cb8cb8b773ccfd4d3"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/freedesktop/poppler"
 PKG_URL="$PKG_SITE.git"
-PKG_DEPENDS_TARGET="toolchain zlib libpng libjpeg-turbo boost"
+PKG_DEPENDS_TARGET="toolchain zlib libpng libjpeg-turbo boost freetype fontconfig glib glib:host"
 PKG_LONGDESC="The poppler pdf rendering library "
 PKG_TOOLCHAIN="cmake"
 
 
 pre_configure_target() { 
-PKG_CMAKE_OPTS_TARGET="-DENABLE_LIBOPENJPEG=none \
+PKG_CMAKE_OPTS_TARGET="-DCMAKE_BUILD_TYPE=release \
+                       -DENABLE_LIBOPENJPEG=none \
                        -DENABLE_GLIB=ON \
                        -DENABLE_QT5=off \
                        -DENABLE_CPP=off"


### PR DESCRIPTION
There is always a bug in poppler's CMake routine that even glib can't be found it still can be built. And there's also another bug that violate's glib's __atomic_load function that's fixed in https://github.com/freedesktop/poppler/commit/bdd110b45a38e8a4f80f522892e4c4a9e432abd5

This bumps poppler to the latest stable version (22.06.0) that includes the above fix, and also fixes its dep problems (added freetype, fontconfig, glib and glib:host as deps)

Tested in clean builds for Amlogic-ng, Amlogic-old, OGA and GF