### PR TITLE
exfat-linux: seperate from linux to save build time

### DIFF
--- a/packages/sx05re/tools/sysutils/exfat-linux/package.mk
+++ b/packages/sx05re/tools/sysutils/exfat-linux/package.mk
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2022-present 7Ji (https://github.com/7Ji)
+
+PKG_NAME="exfat-linux"
+PKG_VERSION="29fdcd25f82439e49d03ed2d5c7d0fd0906f3cb8"
+PKG_SHA256="15d5bff755733442546aec119d7a05e2166af2d034ff0698677e914efe35e1d6"
+PKG_SITE="https://github.com/arter97/exfat-linux"
+PKG_URL="$PKG_SITE/archive/$PKG_VERSION.tar.gz"
+PKG_LONGDESC="exFAT filesystem module for Linux kernel, for extraction in linux package only, DO NOT BUILD"
+PKG_TOOLCHAIN="manual"

--- a/packages/sx05re/tools/sysutils/exfat-linux/package.mk
+++ b/packages/sx05re/tools/sysutils/exfat-linux/package.mk
@@ -8,3 +8,8 @@ PKG_SITE="https://github.com/arter97/exfat-linux"
 PKG_URL="$PKG_SITE/archive/$PKG_VERSION.tar.gz"
 PKG_LONGDESC="exFAT filesystem module for Linux kernel, for extraction in linux package only, DO NOT BUILD"
 PKG_TOOLCHAIN="manual"
+
+unpack() {
+  # This package should not be built, and should not be unpacked to the build dir
+  :
+}

--- a/projects/Amlogic-ce/packages/linux/package.mk
+++ b/projects/Amlogic-ce/packages/linux/package.mk
@@ -10,6 +10,7 @@ PKG_DEPENDS_HOST="ccache:host rsync:host openssl:host"
 PKG_DEPENDS_TARGET="toolchain linux:host kmod:host xz:host keyutils aml-dtbtools:host aml-dtbtools $KERNEL_EXTRA_DEPENDS_TARGET"
 PKG_NEED_UNPACK="$LINUX_DEPENDS $(get_pkg_directory initramfs) $(get_pkg_variable initramfs PKG_NEED_UNPACK)"
 PKG_LONGDESC="This package contains a precompiled kernel image and the modules."
+PKG_DEPENDS_UNPACK+=" exfat-linux"
 PKG_IS_KERNEL_PKG="yes"
 PKG_STAMP="$KERNEL_TARGET $KERNEL_MAKE_EXTRACMD $KERNEL_UBOOT_EXTRA_TARGET"
 
@@ -160,21 +161,13 @@ pre_make_target() {
     sed -i "s|CONFIG_EXTRA_FIRMWARE=.*|CONFIG_EXTRA_FIRMWARE=\"${FW_LIST}\"|" $PKG_BUILD/.config
   fi
 
-  # Add EXFat, from https://github.com/351ELEC/351ELEC/commit/5aac2680bb97a69e0e44e08760caeca9939ab461
-  PREEXF=`pwd`
-  cd ${PKG_BUILD}/fs
-  git clone https://github.com/arter97/exfat-linux.git
-  cd exfat-linux
-  git checkout old
-  cd ${PKG_BUILD}/fs
-  if [ -d "exfat" ]
-  then
-    rm -rf exfat
-  fi
-  mv exfat-linux exfat
-  sed -i '/source "fs\/fat\/Kconfig"/a source "fs\/exfat\/Kconfig"' Kconfig
-  sed -i '/obj-$(CONFIG_FAT_FS).*+= fat\//a obj-$(CONFIG_EXFAT_FS)\t\t+= exfat\/' Makefile
-  cd ${PREEXF}
+  # Add exFAT
+	PKG_BUILD_EXFAT="${PKG_BUILD}/fs/exfat"
+	[ -e "$PKG_BUILD_EXFAT" ] && rm -rf "$PKG_BUILD_EXFAT"
+	mkdir -p "$PKG_BUILD_EXFAT"
+	tar --strip-components=1 -xf "${SOURCES}/exfat-linux/exfat-linux-$(get_pkg_version exfat-linux).tar.gz" -C "$PKG_BUILD_EXFAT"
+  sed -i '/source "fs\/fat\/Kconfig"/a source "fs\/exfat\/Kconfig"' "${PKG_BUILD}/fs/Kconfig"
+  sed -i '/obj-$(CONFIG_FAT_FS).*+= fat\//a obj-$(CONFIG_EXFAT_FS)\t\t+= exfat\/' "${PKG_BUILD}/fs/Makefile"
 
   kernel_make oldconfig
 }

--- a/projects/Amlogic-ce/packages/linux/package.mk
+++ b/projects/Amlogic-ce/packages/linux/package.mk
@@ -166,8 +166,6 @@ pre_make_target() {
 	[ -e "$PKG_BUILD_EXFAT" ] && rm -rf "$PKG_BUILD_EXFAT"
 	mkdir -p "$PKG_BUILD_EXFAT"
 	tar --strip-components=1 -xf "${SOURCES}/exfat-linux/exfat-linux-$(get_pkg_version exfat-linux).tar.gz" -C "$PKG_BUILD_EXFAT"
-  sed -i '/source "fs\/fat\/Kconfig"/a source "fs\/exfat\/Kconfig"' "${PKG_BUILD}/fs/Kconfig"
-  sed -i '/obj-$(CONFIG_FAT_FS).*+= fat\//a obj-$(CONFIG_EXFAT_FS)\t\t+= exfat\/' "${PKG_BUILD}/fs/Makefile"
 
   kernel_make oldconfig
 }


### PR DESCRIPTION
Previously we use a hack ported from 351ELEC to manually clone the exfat-linux repo into the build dir each time we need to build linux. This is dirty and time-consuming as we need to clone that repo from scratch every time we need to build linux.

This seperates exfat-linux into a dedicated "fake" package, whose source will now be handled by LE toolchain, and will only be downloaded once, and used for all builds afterwards without re-downloading

Note that the package exfat-linux is "fake" because it can't be built alone, its only purpose is to let the toolchain download its source package so we can unpack into the source tree of linux when we build linux.