### PR TITLE
Misc depedency fixes (qt-everywhere, ampart)

### DIFF
--- a/packages/sx05re/tools/qt-everywhere/package.mk
+++ b/packages/sx05re/tools/qt-everywhere/package.mk
@@ -8,7 +8,7 @@ PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://qt-project.org"
 PKG_URL="http://download.qt.io/archive/qt/${PKG_VERSION::-2}/${PKG_VERSION}/single/${PKG_NAME}-src-${PKG_VERSION}.tar.xz"
-PKG_DEPENDS_TARGET="pcre2 zlib"
+PKG_DEPENDS_TARGET="pcre2 zlib openssl"
 PKG_SOURCE_DIR="${PKG_NAME}-src-${PKG_VERSION}"
 PKG_LONGDESC="A cross-platform application and UI framework"
 

--- a/projects/Amlogic-ce/packages/tools/ampart/package.mk
+++ b/projects/Amlogic-ce/packages/tools/ampart/package.mk
@@ -9,11 +9,10 @@ PKG_SITE="https://github.com/7Ji/ampart"
 PKG_URL="$PKG_SITE/archive/$PKG_VERSION.tar.gz"
 PKG_MAINTAINER="7Ji"
 PKG_LONGDESC="A simple, fast, yet reliable partition tool for Amlogic's proprietary emmc partition format."
-PKG_DEPENDS_TARGET="toolchain"
+PKG_DEPENDS_TARGET="toolchain zlib u-boot-tools:host"
 PKG_TOOLCHAIN="make"
 
-make_target() {
-  make
+post_make_target(){
   mkimage -A $TARGET_KERNEL_ARCH -O linux -T script -C none -d "$PKG_DIR/oldschool_cfgload.src" 'oldschool_cfgload'
 }
 


### PR DESCRIPTION
qt-everywhere: 
* This pacakge links with openssl which is provided by openssl:target. The build will break if it's built before openssl, this fixes https://github.com/EmuELEC/EmuELEC/issues/952

ampart: 
* This package uses ``mkimage`` to create oldschool_cfgload, which is provided by u-boot-tools:host, the build will break if it's built before u-boot-tools:host
* This package links with zlib to add support for gzipped dtbs, which is provided by zlib:target, the build will break if it's built before zlib. 
* This fixes these two dep problems by adding ``u-boot-tools:host`` and ``zlib`` as dep for target
* The build routine is also slightly adjusted, with ``mkimage`` moved to ``post_make_target()`` now