### PR TITLE
Fix assets dir in devilutionX

### DIFF
--- a/packages/sx05re/emuelec-ports/devilutionX/package.mk
+++ b/packages/sx05re/emuelec-ports/devilutionX/package.mk
@@ -16,7 +16,7 @@ PKG_BUILD_FLAGS="-lto"
 pre_configure_target() {
 PKG_CMAKE_OPTS_TARGET=" -DCMAKE_BUILD_TYPE="Release" -DDEVILUTIONX_STATIC_CXX_STDLIB=OFF -DDISABLE_ZERO_TIER=ON -DBUILD_TESTING=OFF -DBUILD_ASSETS_MPQ=OFF -DDEBUG=OFF -DPREFILL_PLAYER_NAME=ON -DDEVILUTIONX_SYSTEM_LIBSODIUM=OFF"
 
-sed -i "s|assets/|assets_dvx/|" $PKG_BUILD/Source/utils/paths.cpp
+sed -i "s|\"assets\"\ DIRECTORY_SEPARATOR_STR|\"assets_dvx\"\ DIRECTORY_SEPARATOR_STR|" $PKG_BUILD/Source/utils/paths.cpp
 }
 
 makeinstall_target() { 


### PR DESCRIPTION
The assets dir for devilutionX was changed some time ago to "assets_dvx" to avoid conflicts with other assets. The source of devilutionX is patched via a single sed-command in the package.mk file. Due to changes in the devilution source this sed-command patched the wrong line and in the end the assets were no longer found.