### PR TITLE
eemount: introduce package & change mount logic

### DIFF
--- a/packages/sx05re/emuelec/bin/emuelec_autostart.sh
+++ b/packages/sx05re/emuelec/bin/emuelec_autostart.sh
@@ -77,7 +77,11 @@ fi
 setres.sh
 
 # Mounts /storage/roms
-mount_romfs.sh 
+MOUNT_HANDLER=$(get_ee_setting ee_mount.handler)
+if [ -z "$MOUNT_HANDLER" ]; then
+  MOUNT_HANDLER="eemount"
+fi
+$MOUNT_HANDLER &> /emuelec/logs/eemount.log
 
 # copy default bezel to /storage/roms/bezel if it doesn't exists
 if [ ! -f "/storage/roms/bezels/default.cfg" ]; then 

--- a/packages/sx05re/emuelec/bin/emustation-config
+++ b/packages/sx05re/emuelec/bin/emustation-config
@@ -255,21 +255,21 @@ PWDFILE="/flash/ee_defaults.txt"
 [ ! -f "${PWDFILE}" ] && PWDFILE="/storage/roms/ee_defaults.txt"
 [ -f "${PWDFILE}" ] && check_pwd ${PWDFILE}
 
-# Find and mount the ports directory 
-if [ -L "/storage/roms" ]; then
-    LINK=$(readlink /storage/roms)
-else
-    LINK="/storage/roms"
-fi
+# The mounting logic for ports_scripts is now handled in the mount handler
+# # Find and mount the ports directory 
+# if [ -L "/storage/roms" ]; then
+#     LINK=$(readlink /storage/roms)
+# else
+#     LINK="/storage/roms"
+# fi
+# # Just in case
+# mkdir -p "${LINK}/ports_scripts"
+# mkdir -p "/emuelec/ports"
+# mkdir -p "/storage/.tmp/ports-workdir"
+# umount "/storage/roms/ports_scripts" > /dev/null 2>&1
+# umount "/var/media/EEROMS/roms/ports_scripts" > /dev/null 2>&1
 
-# Just in case
-mkdir -p "${LINK}/ports_scripts"
-mkdir -p "/emuelec/ports"
-mkdir -p "/storage/.tmp/ports-workdir"
-umount "/storage/roms/ports_scripts" > /dev/null 2>&1
-umount "/var/media/EEROMS/roms/ports_scripts" > /dev/null 2>&1
-
-mount -t overlay ports -o lowerdir=/usr/bin/ports,upperdir=/emuelec/ports,workdir=/storage/.tmp/ports-workdir "${LINK}/ports_scripts"
+# mount -t overlay ports -o lowerdir=/usr/bin/ports,upperdir=/emuelec/ports,workdir=/storage/.tmp/ports-workdir "${LINK}/ports_scripts"
 
 # wait for all the subshells to finish
 wait

--- a/packages/sx05re/emuelec/config/emuelec/configs/emuelec.conf
+++ b/packages/sx05re/emuelec/config/emuelec/configs/emuelec.conf
@@ -35,10 +35,13 @@ ee_splash.enabled=1
 ## Force splash screens to display for X seconds
 #ee_splash.delay=0
 
-## Some external HDDs take longer to mount than ES to load, if your external ROMS do not mount in time, increase this timer
+## Some external HDDs take longer to mount than ES to load, if your external ROMS do not mount in time, increase this timer. If you have multiple external drives to scan, you must set this according to the slowest drive, as eemount will not rescan external drives as long as at least 1 external drive that provides ROMs is found.
 #ee_load.delay=0
 
-## Retry mounting this many times
+## Mount handler. There're two existing mount handler: eemount (newer and the default, written in C) and mount_romfs.sh (older, written in Bash), and you can write your own. Since it's called in a bash script (emuelec_autostart.sh), setting it to : can disable the whole mounting logic (which is not suggested) if you want to squeeze every last second of booting time.
+#ee_mount.handler=eemount
+
+## Retry mounting this many times, note this is retry, not try, actual try count will +1 (and it can't be disabled even you set it to -1, you must set ee_mount.handler=: if you don't want eemount to work at all). The retry count only affects external drive scanning and does not affect systemd mount units scanning at all.
 ee_mount.retry=1
 
 # Audio device to use, comment for auto, other options 0,0 (default) 0,1 (for some AV outputs)

--- a/packages/sx05re/tools/emuelec-tools/package.mk
+++ b/packages/sx05re/tools/emuelec-tools/package.mk
@@ -50,7 +50,8 @@ PKG_DEPENDS_TARGET+=" ffmpeg \
                       usb-modeswitch \
                       vim \
                       rclone \
-                      grep"
+                      grep \
+                      eemount"
 
 if [ "${PROJECT}" == "Amlogic-ce" ]; then
                       PKG_DEPENDS_TARGET+=" CoreELEC-Debug-Scripts"

--- a/packages/sx05re/tools/sysutils/eemount/package.mk
+++ b/packages/sx05re/tools/sysutils/eemount/package.mk
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: GPL-3.0
+# Copyright (C) 2022-present 7Ji (https://github.com/7Ji)
+
+PKG_NAME="eemount"
+PKG_VERSION="1e83ccd4f76fbb7c08f686e2eff0682fbefd9e40"
+PKG_SHA256="10d8d4b40ee5daa335521ea3d3c0626bde214536f52c69f22bd2ab35f3d40b3e"
+PKG_SITE="https://github.com/7Ji/eemount"
+PKG_URL="${PKG_SITE}/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain systemd"
+PKG_LONGDESC="Multi-source ROMs mounting utility for EmuELEC"
+PKG_TOOLCHAIN="make"

--- a/packages/sysutils/busybox/scripts/fs-resize
+++ b/packages/sysutils/busybox/scripts/fs-resize
@@ -127,7 +127,8 @@ if [ -e /storage/.please_resize_me ] ; then
       esac   
     elif [ "$ROMS_OMIT_MANUAL" ]; then
       echo 'WARNING: EEROMS partition is omitted manually even your drive size is >=8GB, YOU KNOW WHAT YOU ARE DOING'
-      echo > '/flash/ee_fstype' # Mark should be cleaned since the 'no' fstype has no use afterwards
+      mount -o rw,remount /flash
+      rm -f /flash/ee_fstype # Mark should be cleaned since the 'no' fstype has no use afterwards
     else
       echo 'WARNING: EEROMS partition is omitted for <8GB drives'
     fi

--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -703,45 +703,47 @@ mount_storage() {
 
 # EmuELEC specific
 mount_roms() {
-if /usr/bin/busybox mountpoint -q /storage ; then
+  if /usr/bin/busybox mountpoint -q /storage ; then
     progress "Mounting roms"
-  if [ -L "/storage/roms" ]; then
-   /usr/bin/busybox rm /storage/roms > /dev/null 2>&1
-  fi
+    if [ -L "/storage/roms" ]; then
+      /usr/bin/busybox rm -f /storage/roms > /dev/null 2>&1
+    fi
     /usr/bin/busybox mkdir -p /storage/roms > /dev/null 2>&1
 
-# Get EEROMS filetype
-ROM_FS_TYPE="vfat"
+    # Get EEROMS filetype
+    ROM_FS_TYPE="vfat"
 
-if [ -e "/flash/ee_fstype" ]; then
-    EE_FS_TYPE=$(cat "/flash/ee_fstype")
-    
-    case $EE_FS_TYPE in
-    "ntfs"|"ext4"|"exfat")
-        ROM_FS_TYPE=${EE_FS_TYPE}
-    ;;
-    *)
-        # Failsafe
-        ROM_FS_TYPE="vfat"
-    ;;
-    esac 
-fi
-    
+    if [ -e "/flash/ee_fstype" ]; then
+      EE_FS_TYPE=$(cat "/flash/ee_fstype")
+      
+      case $EE_FS_TYPE in
+        "ntfs"|"ext4"|"exfat")
+          ROM_FS_TYPE=${EE_FS_TYPE}
+        ;;
+        *)
+          # Failsafe
+          ROM_FS_TYPE="vfat"
+        ;;
+      esac 
+    fi
+      
     if [ "${ROM_FS_TYPE}" == "ntfs" ]; then 
-        NTFSMOUNT=$(/sysroot/usr/sbin/blkid --label EEROMS)
-        insmod /sysroot/usr/lib/kernel-overlays/base/lib/modules/$(uname -r)/kernel/fs/fuse/fuse.ko > /dev/null 2>&1
-        LD_LIBRARY_PATH=/sysroot/usr/lib /sysroot/usr/bin/ntfs-3g ${NTFSMOUNT} /storage/roms > /dev/null 2>&1
+      NTFSMOUNT=$(/sysroot/usr/sbin/blkid --label EEROMS)
+      insmod /sysroot/usr/lib/kernel-overlays/base/lib/modules/$(uname -r)/kernel/fs/fuse/fuse.ko > /dev/null 2>&1
+      LD_LIBRARY_PATH=/sysroot/usr/lib /sysroot/usr/bin/ntfs-3g ${NTFSMOUNT} /storage/roms > /dev/null 2>&1
     else
-        mount -t ${ROM_FS_TYPE} "LABEL=EEROMS" /storage/roms > /dev/null 2>&1
+      mount -t ${ROM_FS_TYPE} "LABEL=EEROMS" /storage/roms > /dev/null 2>&1
     fi
 
-# If mounting roms partition was succesful, we bind mount the update folder to use the third partition
+    # If mounting roms partition was succesful, we bind mount the update folder to use the third partition
     if /usr/bin/busybox mountpoint -q /storage/roms ; then
-     /usr/bin/busybox mkdir -p /storage/roms/.update > /dev/null 2>&1
-     /usr/bin/busybox mkdir -p "$UPDATE_ROOT" > /dev/null 2>&1
-     mount --bind /storage/roms/.update "$UPDATE_ROOT" > /dev/null 2>&1
+      /usr/bin/busybox mkdir -p /storage/roms/.update > /dev/null 2>&1
+      /usr/bin/busybox mkdir -p "$UPDATE_ROOT" > /dev/null 2>&1
+      mount --bind /storage/roms/.update "$UPDATE_ROOT" > /dev/null 2>&1
     fi
-fi
+  fi
+  # Disable all enabled systemd mount units for /storage/roms and /storage/roms/*, since we will handle them in userland. Starting them then stopping then optionally restarting... It's a huge waste of time and a headache. Especially if the users want to use the systemd-mount for /storage/roms itself yet don't want to use our mount handler, many of them won't even realize storage-roms.mount is definitely up and running at the moment systemd checks for mount units, so their enabled storage-roms.mount won't work at all
+  rm -f /storage/.config/system.d/*.wants/storage-roms*.mount &>/dev/null
 }
 
 # Make last bootloader label (installer, live, run etc.) as the new default

--- a/projects/Amlogic-ce/packages/tools/ampart/package.mk
+++ b/projects/Amlogic-ce/packages/tools/ampart/package.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-3.0
-# Copyright (C) 2022-present 7Ji (pugokushin@gmail.com)
+# Copyright (C) 2022-present 7Ji (https://github.com/7Ji)
 
 PKG_NAME="ampart"
 PKG_VERSION="f0c3cc44ab05586a1b33bbddbf75432de4f1ab58"


### PR DESCRIPTION
This introduces **eemount**, a new package that improves greatly the way EmuELEC handles external ROMs drive and systemd mount units. Users can now mix ROMs across multiple different drives with the ease of plug and play.

All new features are introduced in a backwards-compatible way. Most notably, for each external drive, ``emuelecroms`` mark file now can contain a list of valid system names, and only those systems will be used instead of the whole drive. If the mark file is kept empty, or does not have any valid system names, then the whole drive will be used just like the old ``mount_romfs.sh``

The mounting order is defined as follows (with the mind that systemd mount units persist on root drive explictly set by users should always take priority than plug-and-play external drives):

1. ``/storage/roms`` itself (If either one of the following fails, fall to next one, otherwise skip remaning ones)
    1. systemd mount unit ``/storage/.config/system.d/storage-roms.mount``, it can be any of cifs(samba), nfs, drive, etc that's supported by systemd mount unit
    2. Any external drive auto-mounted by udevil under ``/var/media`` excluding EEROMS that contains an empty ``emuelecroms`` mark or a populated ``emuelecroms`` mark with no valid system entries (*valid here does not neccessarily mean it should be a system supported by EmuELEC to emulate, any non-empty line that does not have a / character and is none of the reserved names (emuelecroms, ports_script) is considered valid, for future-proof if system lists are extended*)  
    The drives are tried one by one in an alphabetical order (which is usually the partition label, but if the partiton does not have label, it will have a name like sda1-blahblah, per the technical details of udevil)
    3. EEROMS
        1. The exact partition that provides mount for ``/storage/.update``, as it is binded from ``/storage/roms (<=LABEL=EEROMS)`` during init
        2. The 3rd partition of the underlying disk of ``/flash (<=LABEL=EMUELEC)`` or ``/storage (<=LABEL=STORAGE)``, if the underlying partition is named in the ``/dev/prefixN`` style (if EE is booted from eMMC whose partitions are named in a ``/dev/well-known`` style, this is omitted)
        3. Any partition with a ``EEROMS`` label (this is least favored as there could be multiple EEROMS partitions, which might screw the mount ``/storage/.update`` we need to take care afterwards)
2. ``/var/media/EEROMS`` :  EEROMS will be mounted to here if it's not used for ``/storage/roms``
3. ``/storage/.update`` : ``.update`` sub-folder under EEROMS will be binded to here, since this is what will be mounted to here during init for update. This mount is made to make sure update package downloaded during user space will be effect during init
4. ``/storage/ports_script`` : Historically this was taken care by ``emustation-config``, now that we manage per-system mounts and it's in the same level of the fs tree of all other systems, we also mount it for the sake of efficiency
5. systems under ``/storage/roms`` (If a system is mounted using a method, the next method will skip that system)
    1. systemd mount units ``/storage/.config/systemd.d/storage-roms-*.mount``, in alphabetial order of the system name (the part between ``storage-roms-`` and ``.mount``).  
    Note a multi-layer mount unit is considered valid (e.g. ``storage-roms-nes-images.mount`` is considered a mount for system ``nes-images``, even it mounts ``/storage/roms/nes/images``) for the ease of management. But **you should avoid this** as it might conflict with a drive mount that provides the layer 1 system (if you have ``storage-roms-nes-images.mount`` but don't have ``storage-roms-nes.mount``, and have a drive that provides ``nes``, ``/storage/roms/nes/images`` from systemd will be stacked under ``/storage/roms/nes`` from that external drive)
    2. Any external drive auto-mounted by udevil under ``/var/media`` excluding EEROMS that contains a populated ``emuelecroms`` mark with valid system entries   
    The drives are tried one-by-one in alphabetical order, then systems on that specific drive being tried are tried one-by-one in alphabetical order

The new utility is written purely in C from ground up using zero existing code bases purely tailored for EmuELEC. It only uses native C calls (no system() functions) which is therefore fast, reliable and compatible. It only takes less than 0.1 second if there're no systemd mount units and only a couple of systems defined, or less than 1 second (averaged at 0.7 second) even there's 57 systems provided by external drives (which is already a stupid number, you should just straight up use the whole drive if you want that many systems from an external drive), or less than 3 seconds even there're multiple systemd mounts from different network shares.

A new setting ``ee_mount.handler`` is introduced into ``emuelec.conf`` that can override the mount handler if user want to use the old ``mount_romfs.sh``, or want to write their own. It can be set to : to completely disable the mounting logic which might help to squeeze the last second of booting time which is not suggested

This also fixes a problem in the updated ``fs-resize`` that the ee_fstype is not correctly removed if it contains ``no`` (it will be not needed anymore in that case) due to ``/flash`` not remounted to rw

I also changed my contact info in ampart's package.mk to sync with other packages including this one

This is tested on the following devices, with multiple different combination of mounting sources, and either ee_fstype=no or not (effectively with&without EEROMS)
 - HK1 BOX (S905X3)
 - BesTV R3300L (S905L)