### PR TITLE
eemount: bump 4adf3138; init: fix disabled systemds units

### DIFF
--- a/packages/sx05re/tools/sysutils/eemount/package.mk
+++ b/packages/sx05re/tools/sysutils/eemount/package.mk
@@ -2,10 +2,11 @@
 # Copyright (C) 2022-present 7Ji (https://github.com/7Ji)
 
 PKG_NAME="eemount"
-PKG_VERSION="1e83ccd4f76fbb7c08f686e2eff0682fbefd9e40"
-PKG_SHA256="10d8d4b40ee5daa335521ea3d3c0626bde214536f52c69f22bd2ab35f3d40b3e"
+PKG_VERSION="4adf31387a9019cb07db861374839d496f2c95e5"
+PKG_SHA256="84b0acb5f3c34a28ddc9e933b50fb2a395b0c044fcc300c79a97f405b0c03773"
 PKG_SITE="https://github.com/7Ji/eemount"
 PKG_URL="${PKG_SITE}/archive/${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain systemd"
 PKG_LONGDESC="Multi-source ROMs mounting utility for EmuELEC"
 PKG_TOOLCHAIN="make"
+PKG_MAKE_OPTS_TARGET="LOGGING_ALL_TO_STDOUT=1"

--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -743,7 +743,8 @@ mount_roms() {
     fi
   fi
   # Disable all enabled systemd mount units for /storage/roms and /storage/roms/*, since we will handle them in userland. Starting them then stopping then optionally restarting... It's a huge waste of time and a headache. Especially if the users want to use the systemd-mount for /storage/roms itself yet don't want to use our mount handler, many of them won't even realize storage-roms.mount is definitely up and running at the moment systemd checks for mount units, so their enabled storage-roms.mount won't work at all
-  rm -f /storage/.config/system.d/*.wants/storage-roms*.mount &>/dev/null
+  # The pattern is splitted to two parts since 1) storage-roms*.mount matches storage-romswhatever.mount which is not what we want; 2) storage-roms{-*,}.mount is not supported by the ASH implemented in busybox
+  rm -f /storage/.config/system.d/*.wants/storage-roms-*.mount /storage/.config/system.d/*.wants/storage-roms.mount &>/dev/null
 }
 
 # Make last bootloader label (installer, live, run etc.) as the new default


### PR DESCRIPTION
New features introduced in eemount:
 - If there's any system mounts (nes, snes, etc) provided by extrenal drives, multi-layer systemd mount units will only be started after them, this avoids them being stacked under external system mounts. The mount order of systems is now as follows:
   - If there's no system mounts provided by external drives:
     - All systemd mount units in alphabetical order (e.g. ``storage-roms-nes.mount`` -> ``storage-roms-nes-images.mount`` -> ``storage-roms-snes.mount`` -> ``storage-roms-snes-images.mount`` -> ...)
   - If there's any system mounts provided by external drives:
     - All systemd layer1 mount units in alphabetical order (e.g.``storage-roms-nes.mount`` -> ``storage-roms-snes.mount`` -> ...)
     - External drive per-system mounts
     - All systemd multi-layer mount units in alphabetical order (e.g.``storage-roms-nes-images.mount`` -> ``storage-roms-snes-images.mount`` -> ...)
   - If there's no systemd mounts, but only external drive mounts
     - External drive per-system mounts
- Reported systemd names are unescaped. This also avoids system mount units with escaped name being stacked under external drive system mounts.
- Logs now contain timestamp (passed time since eemount started). Time can be used by users and devs to profile the performance and adjust some settings.
- A new define macro ``LOGGING_ALL_TO_STDOUT`` is introduced, when defined, all logs will be printed to stdout instead of seperate stdout and stderr, this guarantees the logging order. The package in EmuELEC now defines this, as it is mostly used as a daemon, where its log will be output to ``/emuelec/logs/eemount.log``, and seperate stdout and stderr often results in glitched order

Init fix:
 - Replace systemd mount units disable pattern from ``storage-roms*.mount`` to seperate ``storage-roms.mount`` and ``storage-roms-*.mount``, the former pattern may mistakenly disable mount units irrelative to our mounting logic (e.g. ``storage-roms_backup.mount``)