### PR TITLE
eemount: bump 2321603

### DIFF
--- a/packages/sx05re/tools/sysutils/eemount/package.mk
+++ b/packages/sx05re/tools/sysutils/eemount/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present 7Ji (https://github.com/7Ji)
 
 PKG_NAME="eemount"
-PKG_VERSION="4adf31387a9019cb07db861374839d496f2c95e5"
-PKG_SHA256="84b0acb5f3c34a28ddc9e933b50fb2a395b0c044fcc300c79a97f405b0c03773"
+PKG_VERSION="2321603bdc7a4c09cf805de0e3546512574d8360"
+PKG_SHA256="12cf5fc00291d319f3e598b3b09ac14d591ba86075a61a7a9ed6bd21db16fc78"
 PKG_SITE="https://github.com/7Ji/eemount"
 PKG_URL="${PKG_SITE}/archive/${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain systemd"


### PR DESCRIPTION
Fix:
 - eemount would break when cleaning external drive mounts when there's 0 external mounts, resulting in smbd not being restarted. Since eemount is automatically started on boot, this means smb is therefore broken when there's no external drives. This is now fixed by checking for if any external drives are scanned first, and only clean them if there's any.

Improvement:
 - The whole eeconfig module is re-written from ground up. The config file is now read on demand as a whole, closed, then parsed, this means there will be minumum risk of race-condition now (previously eemount will open the config upon running and kept the file handler, if the config was updated by other programs hotly when eemount is running especially if there's systemd mounts (which means multiple seconds of running time depending on network connection), the older version will still be used, this is actually an impossible accident but I fixed anyway). Since it's read on demand now, the time window during which eemount won't get the updated config is now shrunked to less than 0.1second.
 - Multiple eesettings are parsed one-by-one in the RAM based on the read buffer. This saves the time it needs to read all 3 settings about external mounts. (Previously the file needs to be seeked eveytime another setting needs to be read)
 - Routine is now slightly adjusted, and impact to the bootup speed is pushed to extreme. Only ~0.6 second will be used if there's no mount units, so there's actually almost no need to use a dumb mount handler if user wants speed. (More than half the time is spent on stopping and startting smbd, eemount itself is just fast) This is tested on USB boot and I think eMMC/SD might get even faster
    ```
    [0.613194] [INFO] Job finished successfully
    ```