### PR TITLE
force overwrite file on unziping files

### DIFF
--- a/scripts/extract
+++ b/scripts/extract
@@ -60,7 +60,7 @@ case "${PKG_SOURCE_NAME}" in
     7z x -o"${2}/${1}" "${FULL_SOURCE_PATH}"
     ;;
   *.zip)
-    unzip -q "${FULL_SOURCE_PATH}" -d "${2}"
+    unzip -o -q "${FULL_SOURCE_PATH}" -d "${2}"
     ;;
   *.diff | *.patch)
     patch -d "${2}" -p1 < "${FULL_SOURCE_PATH}"


### PR DESCRIPTION
when a build is interrupted  by some issues, it will cause a re-substitution problem after a rebuild the target whose source code come from a zip file (like target jzintv)
add a "-o" flag to overwrite file on unzipping.