### PR TITLE
Dev joy fixes - Fixes to joy common auto creation of joypad configurations

### DIFF
--- a/packages/sx05re/emuelec/bin/joy_common.sh
+++ b/packages/sx05re/emuelec/bin/joy_common.sh
@@ -27,7 +27,7 @@ jc_get_players() {
     | grep -Ew -B 8 "B: KEY\=[0-9a-f ]+" > /tmp/input_devices
 
 # Determine how many gamepads/players are connected
-  JOYS=$(ls -A1 /dev/input/js*| sort )
+  JOYS=$(ls -A1 /dev/input/js* | sed -e 's|/dev/input/||g' | sort )
   
   declare -a PLAYER_CFGS=()
   

--- a/packages/sx05re/emuelec/config/emuelec/configs/emuelec.conf
+++ b/packages/sx05re/emuelec/config/emuelec/configs/emuelec.conf
@@ -49,13 +49,12 @@ ee_mount.retry=1
 
 # Enable Advance mame auto gamepad configuration 1,0 (default 1)
 advmame_auto_gamepad=1
-
+dolphin_auto_gamepad=1
+flycast_auto_gamepad=1
+mupen64plus_auto_gamepad=1
+ 
 # Enable Advance mame config buttom remapping 1,0 (default 0)
 advmame_joy_remap=1
-
-flycast_joy_remap=1
-
-dolphin_joy_remap=1
 
 AdvanceMame.joy_btns=input a button,input b button,input x button,input y button,input r button,input l button,input r2 button,input l2 button
 


### PR DESCRIPTION
This fixes 2 Bugs:

1. emuelec.conf has the wrong auto configuration variables and values set by default.
2. In joy common the dir path of js[0-9] needs to be removed when auto configuring.

Needs testing.
