### PR TITLE
Check resolution fixes, Setres overhaul, cvbs fix and possibly other resolutions people couldnt see. Borders option added.

### DIFF
--- a/packages/sx05re/emuelec/bin/emuelec-utils
+++ b/packages/sx05re/emuelec/bin/emuelec-utils
@@ -190,22 +190,49 @@ function resolutions() {
 
 	RESOLUTIONS=()
 
-  # N2 supported resolutions source : https://wiki.odroid.com/odroid-n2/application_note/software/set_display_mode
-	N2_SUPPORTED_RESOLUTIONS="480x320p60hz 640x480p60hz 720x480p60hz 720x576p50hz 800x480p60hz 1024x600p60hz 1024x768p60hz 1280x1024p60hz 1280x720p50hz 1280x720p60hz 1280x800p60hz 1360x768p60hz 1440x900p60hz 1600x1200p60hz 1600x900p60hz 1680x1050p60hz 1920x1080p24hz 1920x1080p30hz 1920x1080p50hz 1920x1080p60hz 1920x1200p60hz 2560x1080p60hz 2560x1440p60hz 2560x1600p60hz 3440x1440p60hz 3840x2160p24hz 3840x2160p25hz 3840x2160p30hz 3840x2160p50hz 3840x2160p60hz"
+  if [ -f "/storage/LEGACY_RESOLUTIONS" ]; then
+   # N2 supported resolutions source : https://wiki.odroid.com/odroid-n2/application_note/software/set_display_mode
+   N2_SUPPORTED_RESOLUTIONS="480x320p60hz 640x480p60hz 720x480p60hz 720x576p50hz 800x480p60hz 1024x600p60hz 1024x768p60hz 1280x1024p60hz 1280x720p50hz 1280x720p60hz 1280x800p60hz 1360x768p60hz 1440x900p60hz 1600x1200p60hz 1600x900p60hz 1680x1050p60hz 1920x1080p24hz 1920x1080p30hz 1920x1080p50hz 1920x1080p60hz 1920x1200p60hz 2560x1080p60hz 2560x1440p60hz 2560x1600p60hz 3440x1440p60hz 3840x2160p24hz 3840x2160p25hz 3840x2160p30hz 3840x2160p50hz 3840x2160p60hz"
 
-	# Screen supported resolutions
-	SCREEN_SUPPORTED_RESOLUTIONS=`/usr/bin/cat /sys/class/amhdmitx/amhdmitx0/rawedid | /usr/bin/edid-decode |/usr/bin/grep "@" | sed -E "s| {0,9}VIC {0,9}[0-9]{1,2}||" | /usr/bin/awk '{print $1}' | /usr/bin/sed  's/@/p/g'|/usr/bin/tr '[:upper:]' '[:lower:]'`
+   # Screen supported resolutions
+   SCREEN_SUPPORTED_RESOLUTIONS=`/usr/bin/cat /sys/class/amhdmitx/amhdmitx0/rawedid | /usr/bin/edid-decode |/usr/bin/grep "@" | sed -E "s| {0,9}VIC {0,9}[0-9]{1,2}||" | /usr/bin/awk '{print $1}' | /usr/bin/sed  's/@/p/g'|/usr/bin/tr '[:upper:]' '[:lower:]'`
 
-	for N2SP in $N2_SUPPORTED_RESOLUTIONS
-	do
-	for SSR in $SCREEN_SUPPORTED_RESOLUTIONS
-	do
-		if [ "$N2SP" = "$SSR" ]
-		then
-		RESOLUTIONS+=($N2SP)
-		fi
-	done
-	done
+   for N2SP in $N2_SUPPORTED_RESOLUTIONS
+   do
+   for SSR in $SCREEN_SUPPORTED_RESOLUTIONS
+   do
+    if [ "$N2SP" = "$SSR" ]
+    then
+    RESOLUTIONS+=($N2SP)
+    fi
+   done
+   done
+  fi
+
+  if [[ "$EE_PROJECT" == "Rockchip" ]]; then
+    SCREEN_SUPPORTED_RESOLUTIONS=`/usr/bin/cat /sys/class/display/display0.HDMI/modes | sort -u`
+    for SSR in $SCREEN_SUPPORTED_RESOLUTIONS
+    do
+      RESOLUTIONS+=($SSR)
+    done
+  else
+    # Screen supported resolutions
+   SCREEN_SUPPORTED_RESOLUTIONS=`/usr/bin/cat /sys/class/display/cap | sed '/smpte/d' | sed '/pal/d' | sed '/ntsc/d' | sed 's/\*//' | grep -E '[0-9x]+[pi][56]0hz|cvbs'`
+    for SSR in $SCREEN_SUPPORTED_RESOLUTIONS
+    do
+      RESOLUTIONS+=($SSR)
+    done
+  fi
+
+  if [ "$EE_DEVICE" == "OdroidGoAdvance" ]; then
+    RESOLUTIONS+="480x320p60hz"
+  fi
+
+  if [ "$EE_DEVICE" == "GameForce" ]; then
+    RESOLUTIONS+="640x480p60hz"
+  fi
+
+  RESOLUTIONS=($(printf "%s\n" "${RESOLUTIONS[@]}" | sort -u))
 
 	IFS=","
 	echo "${RESOLUTIONS[*]}"

--- a/packages/sx05re/emuelec/bin/emuelec_autostart.sh
+++ b/packages/sx05re/emuelec/bin/emuelec_autostart.sh
@@ -99,32 +99,6 @@ if [ -f "${BACKUPFILE}" ]; then
 	emuelec-utils ee_backup restore no > /emuelec/logs/last-restore.log 2>&1
 fi
 
-DEFE=""
-
-# If the video-mode is contained in flash config.
-if [ -s "${CONFIG_FLASH}" ]; then
-  CFG_VAL=$(get_config_value "$CONFIG_FLASH" "hdmimode")
-  [ ! -z "$CFG_VAL" ] && DEFE="$CFG_VAL" && set_ee_setting ee_videomode $DEFE
-fi
-
-# Otherwise retrieve via normal methods.
-if [ -z "$DEFE" ]; then
-  if [ -s "/storage/.config/EE_VIDEO_MODE" ]; then
-      DEFE=$(cat /storage/.config/EE_VIDEO_MODE) && set_ee_setting ee_videomode $DEFE
-  fi
-fi
-
-if [ -z "$DEFE" ]; then
-  # Set video mode, this has to be done before starting ES
-  DEFE=$(get_ee_setting ee_videomode)
-  if [ "${DEFE}" == "Custom" ]; then
-      DEFE=$(cat /sys/class/display/mode)
-  fi
-fi
-
-# finally we correct the FB according to video mode
-setres.sh ${DEFE}
-
 # Clean cache garbage when boot up.
 rm -rf /storage/.cache/cores/* &
 
@@ -142,6 +116,9 @@ case "$DEFE" in
 	systemctl start sshd
 	;;
 esac
+
+FILE_MODE="/sys/class/display/mode"
+[[ -f "$FILE_MODE" ]] && setres.sh
 
 # Show splash creen 
 show_splash.sh intro

--- a/packages/sx05re/emuelec/bin/emustation-config
+++ b/packages/sx05re/emuelec/bin/emustation-config
@@ -11,6 +11,7 @@
 
 function check_pwd() {
 
+CONFIG_FLASH="/flash/config.ini"
 EE_CONF="${EE_DIR}/configs/emuelec.conf"
 ESSETTINGS="/storage/.config/emulationstation/es_settings.cfg"
 
@@ -284,5 +285,31 @@ if [[ "$BTENABLED" == "1" ]]; then
 fi
 
 emuelec-utils setauddev
+
+DEFE=""
+
+# If the video-mode is contained in flash config.
+if [ -s "${CONFIG_FLASH}" ]; then
+  CFG_VAL=$(get_config_value "$CONFIG_FLASH" "vout")
+  [ ! -z "$CFG_VAL" ] && DEFE="$CFG_VAL" && set_ee_setting ee_videomode $DEFE
+fi
+
+# Otherwise retrieve via normal methods.
+if [ -z "$DEFE" ]; then
+  if [ -s "/storage/.config/EE_VIDEO_MODE" ]; then
+      DEFE=$(cat /storage/.config/EE_VIDEO_MODE) && \
+        set_ee_setting ee_videomode $DEFE && \
+        mv /storage/.config/EE_VIDEO_MODE /storage/.config/EE_VIDEO_MODE_2
+  fi
+fi
+
+if [ -z "$DEFE" ]; then
+  # Set video mode, this has to be done before starting ES
+  DEFE=$(get_ee_setting ee_videomode)
+fi
+
+# finally we correct the FB according to video mode
+[[ ! -z "$DEFE" ]] && setres.sh ${DEFE}
+
 
 exit 0

--- a/packages/sx05re/emuelec/bin/setres.sh
+++ b/packages/sx05re/emuelec/bin/setres.sh
@@ -110,29 +110,30 @@ echo 0 0 $W1 $H1 > /sys/class/graphics/fb0/free_scale_axis
 echo 0 > /sys/class/graphics/fb0/free_scale
 echo 0 > /sys/class/graphics/fb0/freescale_mode
 
-BORDER_SIZE=$(get_ee_setting ee_videoborder)
-BORDER_SIZE_X=0
-BORDER_SIZE_Y=0
-if [[ -n ${BORDER_SIZE} && ${BORDER_SIZE} > 0 ]]; then
-  BORDER_SIZE_X=${BORDER_SIZE}
-  BORDER_SIZE_Y=${BORDER_SIZE}
+BORDER_VALS=$(get_ee_setting ee_videowindow)
+if [[ ! -z "${BORDER_VALS}" ]]; then
+  BORDERS=(${BORDER_SIZE})
+  COUNT_ARGS=${#PLAYER_CFGS[@]}
+  if [[ "${COUNT_ARGS}" != 4 ]]; then
+    exit 0;
+  fi
+else
+  if [[ "${MODE}" == "480cvbs" ]];
+    BORDERS=(30 10 669 469)
+  fi
+  if [[ "${MODE}" == "576cvbs" ]];
+    BORDERS=(35 20 680 565)
+  fi    
 fi
 
-if [[ -z ${BORDER_SIZE} || ${BORDER_SIZE} == 0 ]]; then
-  BORDER_SIZE_X=$(get_ee_setting ee_videoborderx)
-  BORDER_SIZE_Y=$(get_ee_setting ee_videobordery)
-  [[ -z ${BORDER_SIZE_X} ]] && BORDER_SIZE_X=0
-  [[ -z ${BORDER_SIZE_Y} ]] && BORDER_SIZE_Y=0
-fi
-
-if [[ -n ${BORDER_SIZE_X} && -n ${BORDER_SIZE_Y} ]]; then
-  if [[ ${BORDER_SIZE_X} > 0 || ${BORDER_SIZE_Y} > 0 ]]; then
-    SCALE_W=$(( $W1 - $BORDER_SIZE_X ))
-    SCALE_H=$(( $H1 - $BORDER_SIZE_Y ))
-    echo ${BORDER_SIZE_X} ${BORDER_SIZE_Y} ${SCALE_W} ${SCALE_H} > /sys/class/graphics/fb0/window_axis
+if [[ ! -z "${BORDERS}" ]]; then
+    PX=$BORDERS[0]
+    PY=$BORDERS[1]
+    PW=$BORDERS[2]
+    PH=$BORDERS[3]
+    echo ${PX} ${PY} ${PW} ${PH} > /sys/class/graphics/fb0/window_axis
     echo 1 > /sys/class/graphics/fb0/freescale_mode
     echo 0x10001 > /sys/class/graphics/fb0/free_scale
-  fi
 fi
 
 echo 1 > /sys/class/graphics/fb1/blank

--- a/packages/sx05re/emuelec/bin/setres.sh
+++ b/packages/sx05re/emuelec/bin/setres.sh
@@ -115,10 +115,10 @@ if [[ ! -z "${BORDER_VALS}" ]]; then
   fi
 else
   if [[ "${MODE}" == "480cvbs" ]]; then
-    BORDERS=(30 10 669 469)
+    BORDERS=(10 10 620 480)
   fi
   if [[ "${MODE}" == "576cvbs" ]]; then
-    BORDERS=(35 20 680 565)
+    BORDERS=(15 15 690 546)
   fi    
 fi
 

--- a/packages/sx05re/emuelec/bin/setres.sh
+++ b/packages/sx05re/emuelec/bin/setres.sh
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2019-present Shanti Gilbert (https://github.com/shantigilbert)
+# Copyright (C) 2022-present Joshua L (https://github.com/Langerz82)
 
 # Read the video output mode and set it for emuelec to avoid video flicking.
 
@@ -10,16 +11,8 @@
 
 # set -x #echo on
 
-# 1080p60hz
-# 1080i60hz
-# 720p60hz
-# 720p50hz
-# 480p60hz
-# 480cvbs
-# 576p50hz
-# 1080p50hz
-# 1080i50hz
-# 576cvbs
+# Source predefined functions and variables
+. /etc/profile
 
 # arg1, 1 = Hides, 0 = Show.
 show_buffer ()
@@ -31,103 +24,127 @@ show_buffer ()
 blank_buffer()
 {
   # Blank the buffer.
-  dd if=/dev/zero of=/dev/fb0 bs=12M > /dev/null 2>&1
+  echo 1 > /sys/class/graphics/fb1/blank
+  dd if=/dev/zero of=/dev/fb0 bs=10M > /dev/null 2>&1
 }
 
+# By initially setting with these values we can garuntee the file changes, and the mode corrects itself.
+HACK_480_MODE="640x480p60hz"
+HACK_576_MODE="800x600p60hz"
+
+FILE_MODE="/sys/class/display/mode"
+[[ ! -f "$FILE_MODE" ]] && exit 0;
+
 BPP=32
-HZ=60
 
 MODE=$1
-CUR_MODE=`cat /sys/class/display/mode`;
+DEF_MODE=$(cat $FILE_MODE)
 
 # If the current display is the same as the change just exit.
-[ -z "$MODE" ] && exit 0;
 [[ $MODE == "auto" ]] && exit 0;
-# Removed because if try to set invalid video mode it becomes a valid MODE
-# in display/mode and then when trying to revert back this becomes true exiting.
-#[[ "$MODE" == "$CUR_MODE" ]] && exit 0;
 
 if [[ ! "$MODE" == *"x"* ]]; then
   case $MODE in
-  	*p*) H=$(echo $MODE | cut -d'p' -f 1) ;;
-  	*i*) H=$(echo $MODE | cut -d'i' -f 1) ;;
-  	*cvbs*) H=$(echo $MODE | cut -d'c' -f 1) ;;
+    *p*) H=$(echo $MODE | cut -d'p' -f 1) ;;
+    *i*) H=$(echo $MODE | cut -d'i' -f 1) ;;
   esac
 fi
-
-HZ=${MODE:(-4):2}
-if [[ ! -n "$HZ" ]] || [[ $HZ -eq 50 ]]; then
-	HZ=60
-fi
-
 
 # hides buffer
 show_buffer 1
 
+# This is needed to reset scaling.
+echo 0 > /sys/class/ppmgr/ppscaler
+#echo 0 > /sys/class/graphics/fb0/free_scale
+#echo 1 > /sys/class/graphics/fb0/freescale_mode
+
+if [[ ! "$MODE" == "$DEF_MODE" ]]; then
+  case $MODE in
+    480cvbs)
+      echo $HACK_480_MODE > "${FILE_MODE}"
+      echo 480cvbs > "${FILE_MODE}"
+      ;;
+    576cvbs)
+      echo $HACK_576_MODE > "${FILE_MODE}"
+      echo 576cvbs > "${FILE_MODE}"
+      ;;
+    480p*|480i*|576p*|720p*|1080p*|1440p*|2160p*|576i*|720i*|1080i*|1440i*|2160i*)
+      echo $MODE > "${FILE_MODE}"
+      ;;
+    *x*)
+      echo $MODE > "${FILE_MODE}"
+      ;;
+  esac
+fi
+
 case $MODE in
-	480p*hz|480i*hz|576p*hz|720p*hz|1080p*hz|1440p*hz|2160p*hz|576i*hz|720i*hz|1080i*hz|1440i*hz|2160i*hz)
-    W=$(($H*16/9))
-    [[ "$MODE" == "480"* ]] && W=854
-		DH=$(($H*2))
-		W1=$(($W-1))
-		H1=$(($H-1))
-		fbset -fb /dev/fb0 -g $W $H $W $DH $BPP
-		fbset -fb /dev/fb1 -g $BPP $BPP $BPP $BPP $BPP
-		echo $MODE > /sys/class/display/mode
-		echo 0 > /sys/class/graphics/fb0/free_scale
-		echo 1 > /sys/class/graphics/fb0/freescale_mode
-		echo 0 0 $W1 $H1 > /sys/class/graphics/fb0/free_scale_axis
-		echo 0 0 $W1 $H1 > /sys/class/graphics/fb0/window_axis
-		echo 0 > /sys/class/graphics/fb1/free_scale
-		;;
-	480cvbs)
-    echo 480cvbs > /sys/class/display/mode
-		fbset -fb /dev/fb0 -g 640 480 640 960 $BPP
-		fbset -fb /dev/fb1 -g $BPP $BPP $BPP $BPP $BPP
-		echo 0 0 639 479 > /sys/class/graphics/fb0/free_scale_axis
-		echo 0 0 639 479 > /sys/class/graphics/fb0/window_axis
-		echo 0 > /sys/class/graphics/fb0/free_scale
-		echo 1 > /sys/class/graphics/fb0/freescale_mode    
-		echo 0 > /sys/class/graphics/fb1/free_scale
-		;;
-	576cvbs)
-    echo 576cvbs > /sys/class/display/mode
-		fbset -fb /dev/fb0 -g 720 576 720 1152 $BPP
-		fbset -fb /dev/fb1 -g $BPP $BPP $BPP $BPP $BPP
-		echo 0 0 719 575 > /sys/class/graphics/fb0/free_scale_axis
-		echo 0 0 719 575 > /sys/class/graphics/fb0/window_axis
-		echo 0 > /sys/class/graphics/fb0/free_scale
-		echo 1 > /sys/class/graphics/fb0/freescale_mode    
-    echo 0 > /sys/class/graphics/fb1/free_scale
-		;;
+  480cvbs)
+    W1=639
+    H1=479
+    fbset -fb /dev/fb0 -g 640 480 640 960 $BPP
+    ;;
+  576cvbs)
+    W1=719
+    H1=575
+    fbset -fb /dev/fb0 -g 720 576 720 1152 $BPP
+    ;;
+  480p*|480i*|576p*|720p*|1080p*|1440p*|2160p*|576i*|720i*|1080i*|1440i*|2160i*)
+    W=$(( $H*16/9 ))
+    [[ "$MODE" == "480"* ]] && W=640
+    DH=$(($H*2))
+    W1=$(($W-1))
+    H1=$(($H-1))
+    fbset -fb /dev/fb0 -g $W $H $W $DH $BPP
+    ;;
   *x*)
     W=$(echo $MODE | cut -d'x' -f 1)
     H=$(echo $MODE | cut -d'x' -f 2 | cut -d'p' -f 1)
     [ ! -n "$H" ] && H=$(echo $MODE | cut -d'x' -f 2 | cut -d'i' -f 1)
     if [ -n "$W" ] && [ -n "$H" ]; then
       DH=$(($H*2))
-  		W1=$(($W-1))
-  		H1=$(($H-1))
-  		fbset -fb /dev/fb0 -g $W $H $W $DH $BPP
-  		fbset -fb /dev/fb1 -g $BPP $BPP $BPP $BPP $BPP
-#  		[[ "$MODE" = "720x480p"* ]] && MODE=$(echo "${H}p${HZ}hz")
-  		echo $MODE > /sys/class/display/mode
-  		echo 0 > /sys/class/graphics/fb0/free_scale
-  		echo 1 > /sys/class/graphics/fb0/freescale_mode
-  		echo 0 0 $W1 $H1 > /sys/class/graphics/fb0/free_scale_axis
-  		echo 0 0 $W1 $H1 > /sys/class/graphics/fb0/window_axis
-  		echo 0 > /sys/class/graphics/fb1/free_scale      
+      W1=$(($W-1))
+      H1=$(($H-1))
+      fbset -fb /dev/fb0 -g $W $H $W $DH $BPP
     fi
     ;;
 esac
+echo 0 0 $W1 $H1 > /sys/class/graphics/fb0/free_scale_axis
+echo 0 > /sys/class/graphics/fb0/free_scale
+echo 0 > /sys/class/graphics/fb0/freescale_mode
+
+BORDER_SIZE=$(get_ee_setting ee_videoborder)
+BORDER_SIZE_X=0
+BORDER_SIZE_Y=0
+if [[ -n ${BORDER_SIZE} && ${BORDER_SIZE} > 0 ]]; then
+  BORDER_SIZE_X=${BORDER_SIZE}
+  BORDER_SIZE_Y=${BORDER_SIZE}
+fi
+
+if [[ ${BORDER_SIZE_X} == 0 ]]; then
+  BORDER_SIZE_X=$(get_ee_setting ee_videoborderx)
+  BORDER_SIZE_Y=$(get_ee_setting ee_videobordery)
+fi
+
+if [[ -n ${BORDER_SIZE_X} && -n ${BORDER_SIZE_Y} ]]; then
+  if [[ ${BORDER_SIZE_X} > 0 || ${BORDER_SIZE_Y} > 0 ]]; then
+    SCALE_W=$(( $W1 - $BORDER_SIZE_X ))
+    SCALE_H=$(( $H1 - $BORDER_SIZE_Y ))
+    echo ${BORDER_SIZE_X} ${BORDER_SIZE_Y} ${SCALE_W} ${SCALE_H} > /sys/class/graphics/fb0/window_axis
+    echo 1 > /sys/class/graphics/fb0/freescale_mode
+    echo 0x10001 > /sys/class/graphics/fb0/free_scale
+  fi
+fi
+
+echo 1 > /sys/class/graphics/fb1/blank
 
 blank_buffer
 
 # shows buffer
 show_buffer 0
 
+[[ "$EE_DEVICE" == "Amlogic-ng" ]] && fbfix
 
 # End of reading the video output mode and setting it for emuelec to avoid video flicking.
 # The codes can be simplified with "elseif" sentences.
 # The codes for 480I and 576I are adjusted to avoid overscan.
-# Forece 720p50hz to 720p60hz and 1080i/p60hz to 1080i/p60hz since 50hz would make video very choppy.
+# Force 720p50hz to 720p60hz and 1080i/p60hz to 1080i/p60hz since 50hz would make video very choppy.

--- a/packages/sx05re/emuelec/bin/setres.sh
+++ b/packages/sx05re/emuelec/bin/setres.sh
@@ -58,24 +58,22 @@ echo 0 > /sys/class/ppmgr/ppscaler
 #echo 0 > /sys/class/graphics/fb0/free_scale
 #echo 1 > /sys/class/graphics/fb0/freescale_mode
 
-if [[ ! "$MODE" == "$DEF_MODE" ]]; then
-  case $MODE in
-    480cvbs)
-      echo $HACK_480_MODE > "${FILE_MODE}"
-      echo 480cvbs > "${FILE_MODE}"
-      ;;
-    576cvbs)
-      echo $HACK_576_MODE > "${FILE_MODE}"
-      echo 576cvbs > "${FILE_MODE}"
-      ;;
-    480p*|480i*|576p*|720p*|1080p*|1440p*|2160p*|576i*|720i*|1080i*|1440i*|2160i*)
-      echo $MODE > "${FILE_MODE}"
-      ;;
-    *x*)
-      echo $MODE > "${FILE_MODE}"
-      ;;
-  esac
-fi
+case $MODE in
+  480cvbs)
+    echo $HACK_480_MODE > "${FILE_MODE}"
+    echo 480cvbs > "${FILE_MODE}"
+    ;;
+  576cvbs)
+    echo $HACK_576_MODE > "${FILE_MODE}"
+    echo 576cvbs > "${FILE_MODE}"
+    ;;
+  480p*|480i*|576p*|720p*|1080p*|1440p*|2160p*|576i*|720i*|1080i*|1440i*|2160i*)
+    echo $MODE > "${FILE_MODE}"
+    ;;
+  *x*)
+    echo $MODE > "${FILE_MODE}"
+    ;;
+esac
 
 case $MODE in
   480cvbs)

--- a/packages/sx05re/emuelec/bin/setres.sh
+++ b/packages/sx05re/emuelec/bin/setres.sh
@@ -115,10 +115,10 @@ if [[ ! -z "${BORDER_VALS}" ]]; then
   fi
 else
   if [[ "${MODE}" == "480cvbs" ]]; then
-    BORDERS=(10 10 620 480)
+    BORDERS=(10 10)
   fi
   if [[ "${MODE}" == "576cvbs" ]]; then
-    BORDERS=(15 15 690 546)
+    BORDERS=(15 15)
   fi    
 fi
 
@@ -130,11 +130,16 @@ if [[ ! -z "${BORDERS}" ]]; then
     PH=${BORDERS[3]}
     [[ -z "${PH}" ]] && PH=$H
     
-    if [[ -n $PX && -n $PY && -n $PW && -n $PH ]]; then
-      echo "window params all numbers."
-    else
+    if [[ -z "$PX" || -z "$PY" || -z "$PW" || -z "$PH" ]]; then
       exit 0
+    elif [[ ! -n "$PX" || ! -n "$PY" || ! -n "$PW" || ! -n "$PH" ]]; then
+      exit 0
+    elif [[ "$PX" == "0" || "$PY" == "0" || "$PW" == "0" || "$PH" == "0" ]]; then
+      exit 0
+    else
+      echo "All parameters passed: $PX $PY $PW $PH. Autogen: $(( PW-PX-1 )) $(( PH-PY-1 ))"
     fi
+
     echo ${PX} ${PY} $(( PW-PX-1 )) $(( PH-PY-1 )) > /sys/class/graphics/fb0/window_axis
     echo 1 > /sys/class/graphics/fb0/freescale_mode
     echo 0x10001 > /sys/class/graphics/fb0/free_scale

--- a/packages/sx05re/emuelec/bin/setres.sh
+++ b/packages/sx05re/emuelec/bin/setres.sh
@@ -112,25 +112,25 @@ echo 0 > /sys/class/graphics/fb0/freescale_mode
 
 BORDER_VALS=$(get_ee_setting ee_videowindow)
 if [[ ! -z "${BORDER_VALS}" ]]; then
-  BORDERS=(${BORDER_SIZE})
-  COUNT_ARGS=${#PLAYER_CFGS[@]}
+  declare -a BORDERS=(${BORDER_VALS})
+  COUNT_ARGS=${#BORDERS[@]}
   if [[ "${COUNT_ARGS}" != 4 ]]; then
     exit 0;
   fi
 else
-  if [[ "${MODE}" == "480cvbs" ]];
+  if [[ "${MODE}" == "480cvbs" ]]; then
     BORDERS=(30 10 669 469)
   fi
-  if [[ "${MODE}" == "576cvbs" ]];
+  if [[ "${MODE}" == "576cvbs" ]]; then
     BORDERS=(35 20 680 565)
   fi    
 fi
 
 if [[ ! -z "${BORDERS}" ]]; then
-    PX=$BORDERS[0]
-    PY=$BORDERS[1]
-    PW=$BORDERS[2]
-    PH=$BORDERS[3]
+    PX=${BORDERS[0]}
+    PY=${BORDERS[1]}
+    PW=${BORDERS[2]}
+    PH=${BORDERS[3]}
     echo ${PX} ${PY} ${PW} ${PH} > /sys/class/graphics/fb0/window_axis
     echo 1 > /sys/class/graphics/fb0/freescale_mode
     echo 0x10001 > /sys/class/graphics/fb0/free_scale

--- a/packages/sx05re/emuelec/bin/setres.sh
+++ b/packages/sx05re/emuelec/bin/setres.sh
@@ -120,9 +120,11 @@ if [[ -n ${BORDER_SIZE} && ${BORDER_SIZE} > 0 ]]; then
   BORDER_SIZE_Y=${BORDER_SIZE}
 fi
 
-if [[ ${BORDER_SIZE_X} == 0 ]]; then
+if [[ -z ${BORDER_SIZE} || ${BORDER_SIZE} == 0 ]]; then
   BORDER_SIZE_X=$(get_ee_setting ee_videoborderx)
   BORDER_SIZE_Y=$(get_ee_setting ee_videobordery)
+  [[ -z ${BORDER_SIZE_X} ]] && BORDER_SIZE_X=0
+  [[ -z ${BORDER_SIZE_Y} ]] && BORDER_SIZE_Y=0
 fi
 
 if [[ -n ${BORDER_SIZE_X} && -n ${BORDER_SIZE_Y} ]]; then


### PR DESCRIPTION
Ok I overhauled the setres script. Resolutions with double numbers ex: 800x600p60hz, The 60HZ should now be outputting correctly as previously it was faulty.

UPDATED: Ok so I simplified the code a bit. If you want to add a windowed border to the screen in emuelec.conf you have to add the value "ee_videowindow" too and give it 4 or 2 numbers separated by a space. For instance ee_videowindow=50 50 1180 620.

**I'll explain the numbers.** 

Parameter 1 is the X pixel on the screen from the start horizontally (across the screen).
Parameter 2 is the Y pixel on the screen from the start vertically (down the screen).  

_If only 2 parameters are supplied it will adjust the screen uni-formally which means it will essentially keep the screen dimension but just squash the image. Useful if you want a even border around the screen display._

Parameter 3 is the Width in pixels you want the screen display box to be horizontally.
Parameter 4 is the Height in pixels you want the screen display box to be vertically.

So for example if I wanted the bottom to cut out a bit I could supply this to a 1280x720 screen:
In /emuelec/configs/emuelec.conf - add:
```
ee_videowindow=0 0 1280 620
```
And it should cut some of the bottom away.

If I wanted to add a 50 pixel border around the screen I'd use:
```
ee_videowindow=50 50
```

This should also fix allot of bugged resolutions some people have been having. If they have a bug res and they need to test copy this setres.sh into /emuelec/bin directory and it will be used instead by default.

**FOR TESTING Here is the file:** https://gist.githubusercontent.com/Langerz82/46bfdc9fe2fc271b8fbd6e39dd00cf63/raw/0cde997cc24089dd64e7141487b2628fd9436f3f/setres.sh

Continuation from PR:
https://github.com/EmuELEC/EmuELEC/pull/955