### PR TITLE
package emulator advmame - patch for vsync to work with the fps.

### DIFF
--- a/packages/sx05re/emulators/advancemame/bin/advmame.sh
+++ b/packages/sx05re/emulators/advancemame/bin/advmame.sh
@@ -37,6 +37,8 @@ if [ "$EE_DEVICE" != "OdroidGoAdvance" ] && [ "$EE_DEVICE" != "GameForce" ]; the
     sed -i '/device_video_clock/d' $CONFIG_DIR/advmame.rc
     sed -i 's/display_vsync no/display_vsync yes/g' $CONFIG_DIR/advmame.rc
     sed -i 's/misc_smp no/misc_smp yes/g' $CONFIG_DIR/advmame.rc
+    sed -i 's/sync_speed*/sync_speed 1.0/g' $CONFIG_DIR/advmame.rc
+    sed -i 's/sync_fps*/sync_fps auto/g' $CONFIG_DIR/advmame.rc
 
     if [[ -f "/ee_s905" && "$MODE" == "1080p"* ]]; then
         MODE="720p60hz"

--- a/packages/sx05re/emulators/advancemame/bin/advmame.sh
+++ b/packages/sx05re/emulators/advancemame/bin/advmame.sh
@@ -35,11 +35,6 @@ if [ "$EE_DEVICE" != "OdroidGoAdvance" ] && [ "$EE_DEVICE" != "GameForce" ]; the
     sed -i '/device_video_modeline/d' $CONFIG_DIR/advmame.rc
 
     sed -i '/device_video_clock/d' $CONFIG_DIR/advmame.rc
-    sed -i 's/display_vsync no/display_vsync yes/g' $CONFIG_DIR/advmame.rc
-    sed -i 's/misc_smp no/misc_smp yes/g' $CONFIG_DIR/advmame.rc
-    sed -i 's/sync_speed*/sync_speed 1.0/g' $CONFIG_DIR/advmame.rc
-    sed -i 's/sync_fps*/sync_fps auto/g' $CONFIG_DIR/advmame.rc
-
     if [[ -f "/ee_s905" && "$MODE" == "1080p"* ]]; then
         MODE="720p60hz"
     fi

--- a/packages/sx05re/emulators/advancemame/bin/advmame.sh
+++ b/packages/sx05re/emulators/advancemame/bin/advmame.sh
@@ -67,7 +67,7 @@ if [ "$EE_DEVICE" != "OdroidGoAdvance" ] && [ "$EE_DEVICE" != "GameForce" ]; the
             echo "device_video_modeline 640x480_60.00 23.86 640 656 720 800 480 481 484 497 +hsync +vsync" >> $CONFIG_DIR/advmame.rc
         ;;
     esac
-    echo "device_video_clock 1-200 / 1-200 / 30-60" >> $CONFIG_DIR/advmame.rc
+    echo "device_video_clock 1-200 / 1-200 / 25-60" >> $CONFIG_DIR/advmame.rc
 fi
 
 ROMNAME=$(basename $1)

--- a/packages/sx05re/emulators/advancemame/bin/advmame.sh
+++ b/packages/sx05re/emulators/advancemame/bin/advmame.sh
@@ -34,7 +34,6 @@ if [ "$EE_DEVICE" != "OdroidGoAdvance" ] && [ "$EE_DEVICE" != "GameForce" ]; the
     MODE=`cat /sys/class/display/mode`;
     sed -i '/device_video_modeline/d' $CONFIG_DIR/advmame.rc
 
-    sed -i '/device_video_clock/d' $CONFIG_DIR/advmame.rc
     if [[ -f "/ee_s905" && "$MODE" == "1080p"* ]]; then
         MODE="720p60hz"
     fi
@@ -62,7 +61,6 @@ if [ "$EE_DEVICE" != "OdroidGoAdvance" ] && [ "$EE_DEVICE" != "GameForce" ]; the
             echo "device_video_modeline 640x480_60.00 23.86 640 656 720 800 480 481 484 497 +hsync +vsync" >> $CONFIG_DIR/advmame.rc
         ;;
     esac
-    echo "device_video_clock 1-200 / 1-200 / 25-60" >> $CONFIG_DIR/advmame.rc
 fi
 
 ROMNAME=$(basename $1)

--- a/packages/sx05re/emulators/advancemame/bin/advmame.sh
+++ b/packages/sx05re/emulators/advancemame/bin/advmame.sh
@@ -67,7 +67,7 @@ if [ "$EE_DEVICE" != "OdroidGoAdvance" ] && [ "$EE_DEVICE" != "GameForce" ]; the
         ;;
     esac
     echo "sync_fps ${FPS}" >> $CONFIG_DIR/advmame.rc
-    echo "device_video_clock 1-200 / 1-200 / ${FPS}" >> $CONFIG_DIR/advmame.rc
+    echo "device_video_clock 1-200 / 1-200 / 30-70" >> $CONFIG_DIR/advmame.rc
 fi
 
 ROMNAME=$(basename $1)

--- a/packages/sx05re/emulators/advancemame/bin/advmame.sh
+++ b/packages/sx05re/emulators/advancemame/bin/advmame.sh
@@ -33,16 +33,15 @@ if [ "$EE_DEVICE" != "OdroidGoAdvance" ] && [ "$EE_DEVICE" != "GameForce" ]; the
     unset DISPLAY
     MODE=`cat /sys/class/display/mode`;
     sed -i '/device_video_modeline/d' $CONFIG_DIR/advmame.rc
- sed -i '/sync_fps/d' $CONFIG_DIR/advmame.rc
- sed -i '/device_video_clock/d' $CONFIG_DIR/advmame.rc
- sed -i '/sync_speed/d' $CONFIG_DIR/advmame.rc
- echo "sync_speed 1.0" >> $CONFIG_DIR/advmame.rc
+
+    sed -i '/device_video_clock/d' $CONFIG_DIR/advmame.rc
+    sed -i 's/display_vsync no/display_vsync yes/g' $CONFIG_DIR/advmame.rc
+    sed -i 's/misc_smp no/misc_smp yes/g' $CONFIG_DIR/advmame.rc
 
     if [[ -f "/ee_s905" && "$MODE" == "1080p"* ]]; then
         MODE="720p60hz"
     fi
 
-    FPS="60"
     case "$MODE" in
         "480p"*)
             echo "device_video_modeline 720x480 15.246 720 762 834 968 480 484 491 525 +hsync +vsync" >> $CONFIG_DIR/advmame.rc
@@ -66,8 +65,7 @@ if [ "$EE_DEVICE" != "OdroidGoAdvance" ] && [ "$EE_DEVICE" != "GameForce" ]; the
             echo "device_video_modeline 640x480_60.00 23.86 640 656 720 800 480 481 484 497 +hsync +vsync" >> $CONFIG_DIR/advmame.rc
         ;;
     esac
-    echo "sync_fps ${FPS}" >> $CONFIG_DIR/advmame.rc
-    echo "device_video_clock 1-200 / 1-200 / 30-70" >> $CONFIG_DIR/advmame.rc
+    echo "device_video_clock 1-200 / 1-200 / 30-60" >> $CONFIG_DIR/advmame.rc
 fi
 
 ROMNAME=$(basename $1)

--- a/packages/sx05re/emulators/advancemame/bin/advmame.sh
+++ b/packages/sx05re/emulators/advancemame/bin/advmame.sh
@@ -33,11 +33,16 @@ if [ "$EE_DEVICE" != "OdroidGoAdvance" ] && [ "$EE_DEVICE" != "GameForce" ]; the
     unset DISPLAY
     MODE=`cat /sys/class/display/mode`;
     sed -i '/device_video_modeline/d' $CONFIG_DIR/advmame.rc
+ sed -i '/sync_fps/d' $CONFIG_DIR/advmame.rc
+ sed -i '/device_video_clock/d' $CONFIG_DIR/advmame.rc
+ sed -i '/sync_speed/d' $CONFIG_DIR/advmame.rc
+ echo "sync_speed 1.0" >> $CONFIG_DIR/advmame.rc
 
     if [[ -f "/ee_s905" && "$MODE" == "1080p"* ]]; then
         MODE="720p60hz"
     fi
 
+    FPS="60"
     case "$MODE" in
         "480p"*)
             echo "device_video_modeline 720x480 15.246 720 762 834 968 480 484 491 525 +hsync +vsync" >> $CONFIG_DIR/advmame.rc
@@ -48,16 +53,21 @@ if [ "$EE_DEVICE" != "OdroidGoAdvance" ] && [ "$EE_DEVICE" != "GameForce" ]; the
         "1080p"*)
             echo "device_video_modeline 1920x1080_60.00 153.234 1920 1968 2121 2168 1080 1127 1130 1178 +hsync +vsync" >> $CONFIG_DIR/advmame.rc
         ;;
-        "1280x1024p60hz"*)
+        "1280x1024p60hz")
             echo "device_video_modeline 1280x1024_60.00 108.88 1280 1360 1496 1712 1024 1025 1028 1060 +hsync +vsync" >> $CONFIG_DIR/advmame.rc
         ;;
-        "1024x768p60hz"*)
+        "1024x768p60hz")
             echo "device_video_modeline 1024x768_60.00 64.11 1024 1080 1184 1344 768 769 772 795 +hsync +vsync" >> $CONFIG_DIR/advmame.rc
         ;;
-        "640x480p60hz"*)
+        "800x600p60hz")
+            echo "device_video_modeline 800x600_60.00 38.22 800 832 912 1024 600 601 604 622 +hsync +vsync" >> $CONFIG_DIR/advmame.rc
+        ;;
+        "640x480p60hz")
             echo "device_video_modeline 640x480_60.00 23.86 640 656 720 800 480 481 484 497 +hsync +vsync" >> $CONFIG_DIR/advmame.rc
         ;;
     esac
+    echo "sync_fps ${FPS}" >> $CONFIG_DIR/advmame.rc
+    echo "device_video_clock 1-200 / 1-200 / ${FPS}" >> $CONFIG_DIR/advmame.rc
 fi
 
 ROMNAME=$(basename $1)

--- a/packages/sx05re/emulators/advancemame/patches/advancemame-fix-vfb-fps.patch
+++ b/packages/sx05re/emulators/advancemame/patches/advancemame-fix-vfb-fps.patch
@@ -74,7 +74,7 @@ index c25bca05..7886f78c 100644
  			if (fb_state.wait_error > WAIT_ERROR_MAX)
  				fb_state.wait = fb_wait_none;
 diff --git a/advance/osd/glue.c b/advance/osd/glue.c
-index f6990e46..5d2c5ff0 100644
+index f6990e46..6d3e6102 100644
 --- a/advance/osd/glue.c
 +++ b/advance/osd/glue.c
 @@ -100,6 +100,7 @@ struct advance_glue_context {
@@ -97,13 +97,7 @@ index f6990e46..5d2c5ff0 100644
  #ifdef MESS
  const char* crcfile;
  const char* pcrcfile;
-@@ -777,11 +783,18 @@ int mame_game_run(struct advance_context* context, const struct mame_option* adv
- 			break;
- 	assert(drivers[game_index] != 0);
- 	if (!drivers[game_index])
--		return -1;
-+		return -1;	
- 
+@@ -782,6 +788,13 @@ int mame_game_run(struct advance_context* context, const struct mame_option* adv
  	GLUE.sound_speed = context->video.config.fps_speed_factor;
  	GLUE.sound_fps = context->video.config.fps_fixed;
  
@@ -111,14 +105,14 @@ index f6990e46..5d2c5ff0 100644
 +	globals.sound_speed = &(GLUE.sound_speed);
 +	globals.sound_fps = &(GLUE.sound_fps);
 +	globals.fps_speed_factor = &(context->video.config.fps_speed_factor);
-+	globals.fps_fixed = (context->video.config.fps_fixed > 0.0) ? context->video.config.fps_fixed : globals.mode_vclock;
++	globals.fps_fixed = context->video.config.fps_fixed;
 +#endif
 +
  	hardware_script_info(mame_game_description(context->game), mame_game_manufacturer(context->game), mame_game_year(context->game), "Loading");
  
  	r = run_game(game_index);
 diff --git a/src/mame.c b/src/mame.c
-index 2d7eb97a..65405e53 100644
+index 2d7eb97a..013df92f 100644
 --- a/src/mame.c
 +++ b/src/mame.c
 @@ -229,6 +229,9 @@ const char *memory_region_names[REGION_MAX] =
@@ -136,7 +130,7 @@ index 2d7eb97a..65405e53 100644
  			init_machine();
  
 +			printf("globals.fps_fixed: %f",globals.fps_fixed);
-+			if (Machine->refresh_rate != globals.fps_fixed) {
++			if (globals.fps_fixed > 0.0 && Machine->refresh_rate != globals.fps_fixed) {
 +				*(globals.sound_fps) = globals.fps_fixed;
 +				*(globals.fps_speed_factor) = Machine->refresh_rate / globals.fps_fixed;
 +				*(globals.sound_speed) = globals.fps_fixed / Machine->refresh_rate;

--- a/packages/sx05re/emulators/advancemame/patches/advancemame-fix-vfb-fps.patch
+++ b/packages/sx05re/emulators/advancemame/patches/advancemame-fix-vfb-fps.patch
@@ -74,18 +74,10 @@ index c25bca05..7886f78c 100644
  			if (fb_state.wait_error > WAIT_ERROR_MAX)
  				fb_state.wait = fb_wait_none;
 diff --git a/advance/osd/glue.c b/advance/osd/glue.c
-index f6990e46..6d3e6102 100644
+index f6990e46..2871270d 100644
 --- a/advance/osd/glue.c
 +++ b/advance/osd/glue.c
-@@ -100,6 +100,7 @@ struct advance_glue_context {
- 	char software_buffer[256]; /**< Buffer for software name. */
- 
- 	unsigned input; /**< Last user interface input. */
-+
- };
- 
- static struct advance_glue_context GLUE;
-@@ -110,6 +111,11 @@ static struct advance_glue_context GLUE;
+@@ -110,6 +110,11 @@ static struct advance_glue_context GLUE;
  /* MAME internal variables */
  extern char* cheatfile;
  extern const char *db_filename;
@@ -97,7 +89,7 @@ index f6990e46..6d3e6102 100644
  #ifdef MESS
  const char* crcfile;
  const char* pcrcfile;
-@@ -782,6 +788,13 @@ int mame_game_run(struct advance_context* context, const struct mame_option* adv
+@@ -782,6 +787,13 @@ int mame_game_run(struct advance_context* context, const struct mame_option* adv
  	GLUE.sound_speed = context->video.config.fps_speed_factor;
  	GLUE.sound_fps = context->video.config.fps_fixed;
  
@@ -112,27 +104,25 @@ index f6990e46..6d3e6102 100644
  
  	r = run_game(game_index);
 diff --git a/src/mame.c b/src/mame.c
-index 2d7eb97a..013df92f 100644
+index 2d7eb97a..b37f5924 100644
 --- a/src/mame.c
 +++ b/src/mame.c
-@@ -229,6 +229,9 @@ const char *memory_region_names[REGION_MAX] =
+@@ -229,6 +229,7 @@ const char *memory_region_names[REGION_MAX] =
  	"REGION_PLDS"
  };
  
-+_globals globals = {
-+	.mode_vclock = 60
-+};
++_globals globals;
  
  /***************************************************************************
      PROTOTYPES
-@@ -303,6 +306,14 @@ int run_game(int game)
+@@ -303,6 +304,14 @@ int run_game(int game)
  			/* then finish setting up our local machine */
  			init_machine();
  
 +			printf("globals.fps_fixed: %f",globals.fps_fixed);
 +			if (globals.fps_fixed > 0.0 && Machine->refresh_rate != globals.fps_fixed) {
 +				*(globals.sound_fps) = globals.fps_fixed;
-+				*(globals.fps_speed_factor) = Machine->refresh_rate / globals.fps_fixed;
++				*(globals.fps_speed_factor) *= Machine->refresh_rate / globals.fps_fixed;
 +				*(globals.sound_speed) = globals.fps_fixed / Machine->refresh_rate;
 +				Machine->refresh_rate = globals.fps_fixed;
 +			}
@@ -140,27 +130,17 @@ index 2d7eb97a..013df92f 100644
  			/* load the configuration settings and NVRAM */
  			settingsloaded = config_load_settings();
  			nvram_load();
-@@ -1047,6 +1058,8 @@ static void destroy_machine(void)
- static void init_machine(void)
- {
- 	int num;
-+	
-+
- 
- 	/* initialize basic can't-fail systems here */
- 	cpuintrf_init();
 diff --git a/src/mame.h b/src/mame.h
-index 2b920a1b..6ae9835b 100644
+index 2b920a1b..a47751a8 100644
 --- a/src/mame.h
 +++ b/src/mame.h
-@@ -182,6 +182,14 @@ struct ImageFile
+@@ -182,6 +182,13 @@ struct ImageFile
  };
  #endif /* MESS */
  
 +typedef struct __globals _globals;
 +struct __globals {
 +	double fps_fixed;
-+	double mode_vclock;
 +	double* fps_speed_factor;
 +	double* sound_speed;
 +	double* sound_fps;

--- a/packages/sx05re/emulators/advancemame/patches/advancemame-fix-vfb-fps.patch
+++ b/packages/sx05re/emulators/advancemame/patches/advancemame-fix-vfb-fps.patch
@@ -1,8 +1,8 @@
 diff --git a/advance/linux/vfb.c b/advance/linux/vfb.c
-index c25bca05..57edbac7 100644
+index c25bca05..7886f78c 100644
 --- a/advance/linux/vfb.c
 +++ b/advance/linux/vfb.c
-@@ -1707,7 +1726,7 @@ static adv_error fb_wait_vsync_ext(void)
+@@ -1707,7 +1707,7 @@ static adv_error fb_wait_vsync_ext(void)
  	if (ioctl(fb_state.fd, FBIO_WAITFORVSYNC, 0) != 0) {
  		log_std(("WARNING:video:fb: ioctl(FBIO_WAITFORVSYNC) failed\n"));
  		/* it may be not supported, it isn't an error */
@@ -11,7 +11,7 @@ index c25bca05..57edbac7 100644
  	}
  
  	return 0;
-@@ -1727,7 +1746,7 @@ static adv_error fb_wait_vsync_api(void)
+@@ -1727,7 +1727,7 @@ static adv_error fb_wait_vsync_api(void)
  	if (ioctl(fb_state.fd, FBIOGET_VBLANK, &blank) != 0) {
  		log_std(("WARNING:video:fb: ioctl(FBIOGET_VBLANK) failed\n"));
  		/* it may be not supported, it isn't an error */
@@ -20,7 +20,7 @@ index c25bca05..57edbac7 100644
  	}
  
  	if ((blank.flags & FB_VBLANK_HAVE_COUNT) != 0) {
-@@ -1803,9 +1822,13 @@ static adv_error fb_wait_vsync_vga(void)
+@@ -1803,9 +1803,13 @@ static adv_error fb_wait_vsync_vga(void)
  
  void fb_wait_vsync(void)
  {
@@ -36,7 +36,7 @@ index c25bca05..57edbac7 100644
  			++fb_state.wait_error;
  			if (fb_state.wait_error > WAIT_ERROR_MAX)
  				fb_state.wait = fb_wait_none;
-@@ -1814,7 +1837,10 @@ void fb_wait_vsync(void)
+@@ -1814,7 +1818,10 @@ void fb_wait_vsync(void)
  		}
  		break;
  	case fb_wait_api:
@@ -48,7 +48,7 @@ index c25bca05..57edbac7 100644
  			++fb_state.wait_error;
  			if (fb_state.wait_error > WAIT_ERROR_MAX)
  				fb_state.wait = fb_wait_none;
-@@ -1834,18 +1860,21 @@ void fb_wait_vsync(void)
+@@ -1834,18 +1841,21 @@ void fb_wait_vsync(void)
  		break;
  #endif
  	case fb_wait_detect:
@@ -73,3 +73,104 @@ index c25bca05..57edbac7 100644
  			++fb_state.wait_error;
  			if (fb_state.wait_error > WAIT_ERROR_MAX)
  				fb_state.wait = fb_wait_none;
+diff --git a/advance/osd/glue.c b/advance/osd/glue.c
+index f6990e46..5d2c5ff0 100644
+--- a/advance/osd/glue.c
++++ b/advance/osd/glue.c
+@@ -100,6 +100,7 @@ struct advance_glue_context {
+ 	char software_buffer[256]; /**< Buffer for software name. */
+ 
+ 	unsigned input; /**< Last user interface input. */
++
+ };
+ 
+ static struct advance_glue_context GLUE;
+@@ -110,6 +111,11 @@ static struct advance_glue_context GLUE;
+ /* MAME internal variables */
+ extern char* cheatfile;
+ extern const char *db_filename;
++
++#ifndef MESS
++	extern _globals globals;
++#endif
++
+ #ifdef MESS
+ const char* crcfile;
+ const char* pcrcfile;
+@@ -777,11 +783,18 @@ int mame_game_run(struct advance_context* context, const struct mame_option* adv
+ 			break;
+ 	assert(drivers[game_index] != 0);
+ 	if (!drivers[game_index])
+-		return -1;
++		return -1;	
+ 
+ 	GLUE.sound_speed = context->video.config.fps_speed_factor;
+ 	GLUE.sound_fps = context->video.config.fps_fixed;
+ 
++#ifndef MESS
++	globals.sound_speed = &(GLUE.sound_speed);
++	globals.sound_fps = &(GLUE.sound_fps);
++	globals.fps_speed_factor = &(context->video.config.fps_speed_factor);
++	globals.fps_fixed = (context->video.config.fps_fixed > 0.0) ? context->video.config.fps_fixed : globals.mode_vclock;
++#endif
++
+ 	hardware_script_info(mame_game_description(context->game), mame_game_manufacturer(context->game), mame_game_year(context->game), "Loading");
+ 
+ 	r = run_game(game_index);
+diff --git a/src/mame.c b/src/mame.c
+index 2d7eb97a..65405e53 100644
+--- a/src/mame.c
++++ b/src/mame.c
+@@ -229,6 +229,9 @@ const char *memory_region_names[REGION_MAX] =
+ 	"REGION_PLDS"
+ };
+ 
++_globals globals = {
++	.mode_vclock = 60
++};
+ 
+ /***************************************************************************
+     PROTOTYPES
+@@ -303,6 +306,14 @@ int run_game(int game)
+ 			/* then finish setting up our local machine */
+ 			init_machine();
+ 
++			printf("globals.fps_fixed: %f",globals.fps_fixed);
++			if (Machine->refresh_rate != globals.fps_fixed) {
++				*(globals.sound_fps) = globals.fps_fixed;
++				*(globals.fps_speed_factor) = Machine->refresh_rate / globals.fps_fixed;
++				*(globals.sound_speed) = globals.fps_fixed / Machine->refresh_rate;
++				Machine->refresh_rate = globals.fps_fixed;
++			}
++
+ 			/* load the configuration settings and NVRAM */
+ 			settingsloaded = config_load_settings();
+ 			nvram_load();
+@@ -1047,6 +1058,8 @@ static void destroy_machine(void)
+ static void init_machine(void)
+ {
+ 	int num;
++	
++
+ 
+ 	/* initialize basic can't-fail systems here */
+ 	cpuintrf_init();
+diff --git a/src/mame.h b/src/mame.h
+index 2b920a1b..6ae9835b 100644
+--- a/src/mame.h
++++ b/src/mame.h
+@@ -182,6 +182,14 @@ struct ImageFile
+ };
+ #endif /* MESS */
+ 
++typedef struct __globals _globals;
++struct __globals {
++	double fps_fixed;
++	double mode_vclock;
++	double* fps_speed_factor;
++	double* sound_speed;
++	double* sound_fps;
++};
+ 
+ /* The host platform should fill these fields with the preferences specified in the GUI */
+ /* or on the commandline. */

--- a/packages/sx05re/emulators/advancemame/patches/advancemame-fix-vfb-fps.patch
+++ b/packages/sx05re/emulators/advancemame/patches/advancemame-fix-vfb-fps.patch
@@ -1,0 +1,75 @@
+diff --git a/advance/linux/vfb.c b/advance/linux/vfb.c
+index c25bca05..57edbac7 100644
+--- a/advance/linux/vfb.c
++++ b/advance/linux/vfb.c
+@@ -1707,7 +1726,7 @@ static adv_error fb_wait_vsync_ext(void)
+ 	if (ioctl(fb_state.fd, FBIO_WAITFORVSYNC, 0) != 0) {
+ 		log_std(("WARNING:video:fb: ioctl(FBIO_WAITFORVSYNC) failed\n"));
+ 		/* it may be not supported, it isn't an error */
+-		return -1;
++		return -2;
+ 	}
+ 
+ 	return 0;
+@@ -1727,7 +1746,7 @@ static adv_error fb_wait_vsync_api(void)
+ 	if (ioctl(fb_state.fd, FBIOGET_VBLANK, &blank) != 0) {
+ 		log_std(("WARNING:video:fb: ioctl(FBIOGET_VBLANK) failed\n"));
+ 		/* it may be not supported, it isn't an error */
+-		return -1;
++		return -2;
+ 	}
+ 
+ 	if ((blank.flags & FB_VBLANK_HAVE_COUNT) != 0) {
+@@ -1803,9 +1822,13 @@ static adv_error fb_wait_vsync_vga(void)
+ 
+ void fb_wait_vsync(void)
+ {
++	adv_error res = 0;
+ 	switch (fb_state.wait) {
+-	case fb_wait_ext:
+-		if (fb_wait_vsync_ext() != 0) {
++	case fb_wait_ext: 
++		res = fb_wait_vsync_ext();
++		if (res != 0) {
++			if (res == -2)
++				break;
+ 			++fb_state.wait_error;
+ 			if (fb_state.wait_error > WAIT_ERROR_MAX)
+ 				fb_state.wait = fb_wait_none;
+@@ -1814,7 +1837,10 @@ void fb_wait_vsync(void)
+ 		}
+ 		break;
+ 	case fb_wait_api:
+-		if (fb_wait_vsync_api() != 0) {
++		res = fb_wait_vsync_api();
++		if (res != 0) {
++			if (res == -2)
++				break;
+ 			++fb_state.wait_error;
+ 			if (fb_state.wait_error > WAIT_ERROR_MAX)
+ 				fb_state.wait = fb_wait_none;
+@@ -1834,18 +1860,21 @@ void fb_wait_vsync(void)
+ 		break;
+ #endif
+ 	case fb_wait_detect:
+-		if (fb_wait_vsync_ext() == 0) {
++		res = fb_wait_vsync_ext();
++		if (res == 0) {
+ 			fb_state.wait = fb_wait_ext;
+ 			fb_state.wait_error = 0;
+-		} else if (fb_wait_vsync_api() == 0) {
++		} else if ((res = fb_wait_vsync_api()) && res == 0) {
+ 			fb_state.wait = fb_wait_api;
+ 			fb_state.wait_error = 0;
+ #ifdef __i386__
+-		} else if (fb_wait_vsync_vga() == 0) {
++		} else if ((res = fb_wait_vsync_vga()) && res == 0) {
+ 			fb_state.wait = fb_wait_vga;
+ 			fb_state.wait_error = 0;
+ #endif
+ 		} else {
++			if (res==-2)
++				break;
+ 			++fb_state.wait_error;
+ 			if (fb_state.wait_error > WAIT_ERROR_MAX)
+ 				fb_state.wait = fb_wait_none;


### PR DESCRIPTION
Currently the emulator advmame with vsync enabled makes the game speed hyper fast and unplayable.

This fixes the issue of the game speed being correct AND also fixes screen tearing provided the fps is set the same mhz of your display.
