### PR TITLE
emulator - duckstation standalone - game controller autoconfiguration

### DIFF
--- a/packages/sx05re/emulators/duckstation/scripts/duckstation.sh
+++ b/packages/sx05re/emulators/duckstation/scripts/duckstation.sh
@@ -36,7 +36,7 @@ if [ ! -L "${LOCAL_CONFIG}/duckstation" ]; then
 fi
 
 AUTOGP=$(get_ee_setting duckstation_auto_gamepad)
-if [[ "${AUTOGP}" != "0" ]]; then
+if [[ "${AUTOGP}" == "1" ]]; then
 	set_duckstation_joy.sh
 fi
 

--- a/packages/sx05re/emulators/duckstation/scripts/duckstation.sh
+++ b/packages/sx05re/emulators/duckstation/scripts/duckstation.sh
@@ -37,7 +37,7 @@ fi
 
 AUTOGP=$(get_ee_setting duckstation_auto_gamepad)
 if [[ "${AUTOGP}" != "0" ]]; then
-	/usr/bin/set_duckstation_joy.sh
+	set_duckstation_joy.sh
 fi
 
 if [[ "${1}" == *"duckstation_gui.pbp"* ]]; then

--- a/packages/sx05re/emulators/duckstation/scripts/duckstation.sh
+++ b/packages/sx05re/emulators/duckstation/scripts/duckstation.sh
@@ -35,6 +35,11 @@ if [ ! -L "${LOCAL_CONFIG}/duckstation" ]; then
     ln -sf "${CONFIG_DIR}" "${LOCAL_CONFIG}/duckstation"
 fi
 
+AUTOGP=$(get_ee_setting duckstation_auto_gamepad)
+if [[ "${AUTOGP}" != "0" ]]; then
+	/usr/bin/set_duckstation_joy.sh
+fi
+
 if [[ "${1}" == *"duckstation_gui.pbp"* ]]; then
     duckstation-nogui -fullscreen
 else

--- a/packages/sx05re/emulators/duckstation/scripts/set_duckstation_joy.sh
+++ b/packages/sx05re/emulators/duckstation/scripts/set_duckstation_joy.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2022-present Langerz82 (https://github.com/Langerz82)
+
+# Source predefined functions and variables
+. /etc/profile
+
+# Configure ADVMAME players based on ES settings
+CONFIG_DIR="/storage/.config/emuelec/configs/duckstation"
+CONFIG=${CONFIG_DIR}/settings.ini
+
+CONFIG_TMP=/tmp/jc/duckstation.tmp
+
+source /usr/bin/joy_common.sh "duckstation"
+
+declare -A GC_VALUES=(
+[h0.1]="Button11"
+[h0.4]="Button12"
+[h0.8]="Button13"
+[h0.2]="Button14"
+[b0]="Button0"
+[b1]="Button1"
+[b2]="Button2"
+[b3]="Button3"
+[b4]="Button9"
+[b5]="Button10"
+[b6]="Button4"
+[b7]="Button6"
+[b8]="Button5"
+[b9]="Button7"
+[b10]="Button8"
+[b11]="Button11"
+[b12]="Button12"
+[b13]="Button13"
+[b14]="Button14"
+[a0]="Axis0"
+[a1]="Axis1"
+[a2]="+Axis4"
+[a3]="Axis2"
+[a4]="Axis3"
+[a5]="+Axis5"
+)
+
+declare -A GC_BUTTONS=(
+  [dpleft]="ButtonLeft"
+  [dpright]="ButtonRight"
+  [dpup]="ButtonUp"
+  [dpdown]="ButtonDown"
+  [x]="ButtonTriangle"
+  [y]="ButtonSquare"
+  [a]="ButtonCircle"
+  [b]="ButtonCross"
+  [leftshoulder]="ButtonL1"
+  [rightshoulder]="ButtonR1"
+  [lefttrigger]="ButtonL2"
+  [righttrigger]="ButtonR2"
+  [leftstick]="ButtonL3"
+  [rightstick]="ButtonR3"
+  [back]="ButtonSelect"
+  [start]="ButtonStart"
+  [guide]="OpenQuickMenu"
+  [leftx]="AxisLeftX"
+  [lefty]="AxisLeftY"
+  [rightx]="AxisRightX"
+  [righty]="AxisRightY"
+)
+
+declare -A GC_STICKS=(
+)
+
+# Cleans all the inputs for the gamepad with name $GAMEPAD and player $1
+clean_pad() {
+  [[ -f "${CONFIG_TMP}" ]] && rm "${CONFIG_TMP}"
+
+  local START_DELETING=0
+  local GC_REGEX="\[Controller${1}\]"
+  local LN=1
+  [[ ! -f "${CONFIG}" ]] && return
+  while read -r line; do
+    if [[ "$line" =~ \[.+\] ]]; then
+      START_DELETING=0
+    fi
+    local header=$(echo "$line" | grep -E "$GC_REGEX" )
+    if [[ ! -z "$header" ]]; then
+      START_DELETING=1
+    fi    
+    if [[ "$START_DELETING" == "1" ]]; then
+      sed -i "$LN d" "$CONFIG"
+    else
+      LN=$(( $LN + 1 ))  
+    fi
+  done < ${CONFIG}
+}
+
+# Sets pad depending on parameters.
+# $1 = Player Number
+# $2 = js[0-7]
+# $3 = Device GUID
+# $4 = Device Name
+
+set_pad() {
+  local DEVICE_GUID=$3
+  local JOY_NAME="$4"
+
+  echo "DEVICE_GUID=$DEVICE_GUID"
+
+  local GC_CONFIG=$(cat "$GCDB" | grep "$DEVICE_GUID" | grep "platform:Linux" | head -1)
+  echo "GC_CONFIG=$GC_CONFIG"
+  [[ -z $GC_CONFIG ]] && return
+
+  touch "${CONFIG_TMP}"
+
+  local GC_MAP=$(echo $GC_CONFIG | cut -d',' -f3-)
+
+  echo -en "\n[Controller${1}]\n" >> ${CONFIG}
+  declare -i JOY_INDEX=$(( $1 - 1 ))
+  echo "Type = AnalogController" >> ${CONFIG}
+
+  local LINE_INSERT=
+  set -f
+  local GC_ARRAY=(${GC_MAP//,/ })
+  for index in "${!GC_ARRAY[@]}"
+  do
+      local REC=${GC_ARRAY[$index]}
+      local BUTTON_INDEX=$(echo $REC | cut -d ":" -f 1)
+      local TVAL=$(echo $REC | cut -d ":" -f 2)
+      local BUTTON_VAL=${TVAL:1}
+      local GC_INDEX="${GC_BUTTONS[$BUTTON_INDEX]}"
+      local BTN_TYPE=${TVAL:0:1}
+      local VAL="${GC_VALUES[$TVAL]}"
+
+      # CREATE BUTTON MAPS (inlcuding hats).
+      if [[ ! -z "$GC_INDEX" ]]; then
+        if [[ "$BUTTON_INDEX" == "guide" ]]; then
+          LINE_INSERT="${GC_INDEX} = Controller${JOY_INDEX}/${VAL}"
+        else
+          if [[ "$BTN_TYPE" == "b"  || "$BTN_TYPE" == "h" ]]; then
+            [[ ! -z "$VAL" ]] && echo "${GC_INDEX} = Controller${JOY_INDEX}/${VAL}" >> ${CONFIG_TMP}
+          fi
+          if [[ "$BTN_TYPE" == "a" ]]; then
+            [[ ! -z "$VAL" ]] && echo "${GC_INDEX} = Controller${JOY_INDEX}/${VAL}" >> ${CONFIG_TMP}
+          fi
+        fi
+      fi
+  done
+
+  cat "${CONFIG_TMP}" | sort >> ${CONFIG}
+
+  if [[ ! -z "${LINE_INSERT}" ]]; then
+    sed -i "/\[Hotkeys\]/c" ${CONFIG}
+    sed -i "/OpenQuickMenu/c" ${CONFIG}
+    echo -en "\n[Hotkeys]\n" >> ${CONFIG}
+    echo "${LINE_INSERT}" >> ${CONFIG}
+  fi
+
+  rm "${CONFIG_TMP}"
+}
+
+jc_get_players


### PR DESCRIPTION
This is a game controller autoconfiguration script for duckstation standalone.

Needs proper testing.

To enable:
1. SSH in and copy set_duckstation_joy.sh in /emuelec/bin.
2. Add duckstation_auto_gamepad=1 in emuelec.conf. like so:
```
echo "duckstation_auto_gamepad=1" >> /emuelec/configs/emuelec.conf
```
Good luck testing and thanks.