### PR TITLE
Update mkimage to add support gpt as select build option

### DIFF
--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -54,10 +54,13 @@ trap cleanup SIGINT
 echo -e "\nimage: creating sparse file for disk image ${DISK##*/}..."
 dd if=/dev/zero of="${DISK}" bs=1M count=0 seek="${DISK_SIZE}" conv=fsync >"${SAVE_ERROR}" 2>&1 || show_error
 
-if [ "${BOOTLOADER}" = "syslinux" ]; then
-  DISK_LABEL=gpt
-else
-  DISK_LABEL=msdos
+# use user forced disk label if available. Will be useful for big usb hdd over 2TB formatting with gpt.
+if [ "${DISK_LABEL}" = "" ]; then
+  if [ "${BOOTLOADER}" = "syslinux" ]; then
+    DISK_LABEL=gpt
+  else
+    DISK_LABEL=msdos
+  fi
 fi
 
 # write a disklabel


### PR DESCRIPTION
# use user forced disk label if available. Will be useful for big USB HDD over 2TB formatting with gpt.

I tested on my build on a Amlogic S905X4 TV Box with a USB 5TB SATA Seagate HDD, and work with gpt disk formatting. 

Build with 
`PROJECT=Amlogic-ce DEVICE=Amlogic-ng ARCH=aarch64 DISTRO=EmuELEC DISK_LABEL=gpt make image
`

When done, flash the img to the 5TB USB HDD. And plug it to the TV Box USB port. When boot up, I suppose the SATA HDD is slow for init to boot up,  And force to add a TF card (not boot-able) to the TF port, then the BOX boot firstly from the TF card, then check the USB port after then, the 5TB HDD is ready and boot up successfully. Without the TF card in the TV BOX, it can not boot up. 

When done, the EmuELEC will create a 2GB EmuELEC, 6GB STORAGE, 2TB FAT32 EEROMS partitions. I reformat the 2TB FAT32 partition to a 4.5TB exFAT EEROMS partition and it works well.

The only shortcoming is having to keep the TF card in the TV BOX. But I think if you have a speedy USB 5TB SSD, it will boot up correctly without the TF card.

Thank you.
