### PR TITLE
lib32-libdrm: keep up with generic-libdrm

### DIFF
--- a/packages/lib32/graphics/lib32-libdrm/package.mk
+++ b/packages/lib32/graphics/lib32-libdrm/package.mk
@@ -18,13 +18,13 @@ PKG_BUILD_FLAGS="lib32"
 
 get_graphicdrivers
 
-PKG_MESON_OPTS_TARGET="-Dnouveau=false \
-                       -Domap=false \
-                       -Dexynos=false \
-                       -Dtegra=false \
-                       -Dcairo-tests=false \
-                       -Dman-pages=false \
-                       -Dvalgrind=false \
+PKG_MESON_OPTS_TARGET="-Dnouveau=disabled \
+                       -Domap=disabled \
+                       -Dexynos=disabled \
+                       -Dtegra=disabled \
+                       -Dcairo-tests=disabled \
+                       -Dman-pages=disabled \
+                       -Dvalgrind=disabled \
                        -Dfreedreno-kgsl=false \
                        -Dinstall-test-programs=true \
                        -Dudev=false"


### PR DESCRIPTION
libdrm changed a lot of options from ``true/false/auto`` to ``enabled/disabled/auto``, the upstream generic libdrm has adapted to this change. This brings the change to lib32-drm and fixes the following build problem:
```
UNPACK      lib32-libdrm
BUILD      lib32-libdrm (target)
    TOOLCHAIN      meson
Executing (target): meson --prefix=/usr --bindir=/usr/bin --sbindir=/usr/sbin --sysconfdir=/etc --libdir=/usr/lib --libexecdir=/usr/lib --localstatedir=/var --buildtype=plain -Dstrip=true --cross-file=/home/nomad7ji/EmuELEC/build.EmuELEC-RK356x.aarch64-4/build/lib32-libdrm-2.4.113/.armv8a-emuelec-linux-gnueabihf/meson.conf -Dnouveau=false -Domap=false -Dexynos=false -Dtegra=false -Dcairo-tests=false -Dman-pages=false -Dvalgrind=false -Dfreedreno-kgsl=false -Dinstall-test-programs=true -Dudev=false /home/nomad7ji/EmuELEC/build.EmuELEC-RK356x.aarch64-4/build/lib32-libdrm-2.4.113
The Meson build system
Version: 0.63.2
Source dir: /home/nomad7ji/EmuELEC/build.EmuELEC-RK356x.aarch64-4/build/lib32-libdrm-2.4.113
Build dir: /home/nomad7ji/EmuELEC/build.EmuELEC-RK356x.aarch64-4/build/lib32-libdrm-2.4.113/.armv8a-emuelec-linux-gnueabihf
Build type: cross build

../meson.build:21:0: ERROR: Value "false" (of type "string") for combo option "Enable support for nouveau's KMS API." is not one of the choices. Possible choices are (as string): "enabled", "disabled", "auto".

A full log can be found at /home/nomad7ji/EmuELEC/build.EmuELEC-RK356x.aarch64-4/build/lib32-libdrm-2.4.113/.armv8a-emuelec-linux-gnueabihf/meson-logs/meson-log.txt
FAILURE: ./scripts/build lib32-libdrm:target during configure_target (default)
*********** FAILED COMMAND ***********
CC="${HOST_CC}" CXX="${HOST_CXX}" meson ${TARGET_MESON_OPTS} --cross-file=${MESON_CONF} ${PKG_MESON_OPTS_TARGET} ${PKG_MESON_SCRIPT%/*}
**************************************
```