### PR TITLE
ffmpeg: fix dep x264; lib32-ffmpeg: switch to openssl

### DIFF
--- a/packages/lib32/multimedia/lib32-ffmpeg/package.mk
+++ b/packages/lib32/multimedia/lib32-ffmpeg/package.mk
@@ -10,7 +10,7 @@ PKG_ARCH="aarch64"
 PKG_LICENSE="LGPLv2.1+"
 PKG_SITE="https://ffmpeg.org"
 PKG_URL=""
-PKG_DEPENDS_TARGET="lib32-toolchain lib32-zlib lib32-bzip2 lib32-gnutls lib32-SDL2"
+PKG_DEPENDS_TARGET="lib32-toolchain lib32-zlib lib32-bzip2 lib32-openssl lib32-SDL2"
 PKG_LONGDESC="FFmpeg is a complete, cross-platform solution to record, convert and stream audio and video."
 PKG_BUILD_FLAGS="lib32 -gold"
 
@@ -84,7 +84,7 @@ configure_target() {
               --disable-static \
               --enable-shared \
               --enable-gpl \
-              --disable-version3 \
+              --enable-version3 \
               --enable-logging \
               --disable-doc \
               --disable-debug \
@@ -101,8 +101,8 @@ configure_target() {
               --enable-avfilter \
               --enable-pthreads \
               --enable-network \
-              --enable-gnutls \
-              --disable-openssl \
+              --disable-gnutls \
+              --enable-openssl \
               --disable-gray \
               --enable-swscale-alpha \
               --disable-small \

--- a/packages/multimedia/ffmpeg/package.mk
+++ b/packages/multimedia/ffmpeg/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="ffmpeg"
 PKG_LICENSE="LGPLv2.1+"
 PKG_SITE="https://ffmpeg.org"
-PKG_DEPENDS_TARGET="toolchain zlib bzip2 openssl speex SDL2 lame"
+PKG_DEPENDS_TARGET="toolchain zlib bzip2 openssl speex SDL2 lame x264"
 PKG_LONGDESC="FFmpeg is a complete, cross-platform solution to record, convert and stream audio and video."
 PKG_BUILD_FLAGS="-gold"
 


### PR DESCRIPTION
We always enabled x264 support in ffmpeg in our past EmuELEC builds, while upstream LE and CE don't. During the last merge from upstream where the dependency of ffmpeg changed from gnutls to openssl, the x264 dependency was accidentally dropped. This re-adds x264 to ffmpeg's dependency, and adapt lib32-ffmpeg to also use openssl instead of gnutls

Test builds successful on Amlogic-ng and Amlogic-old