### PR TITLE
options: raise default ccache limit to 20G

### DIFF
--- a/config/options
+++ b/config/options
@@ -104,7 +104,7 @@ VERBOSE="${VERBOSE:-yes}"
 # value. The default is gigabytes. The actual value stored is rounded down to
 # the nearest multiple of 16 kilobytes.  Keep in mind this per project .ccache
 # directory.
-CCACHE_CACHE_SIZE="10G"
+CCACHE_CACHE_SIZE="20G"
 
 # set addon paths
 if [ -z "$ADDON_PATH" ]; then


### PR DESCRIPTION
The default ccache size limit (10G) is well enough for the upstream projects where it came from (CE & LE):
```
~$ du -sh CoreELEC/build.CoreELEC-Amlogic-ng.arm-20/.ccache/
5.9G    CoreELEC/build.CoreELEC-Amlogic-ng.arm-20/.ccache/
```
But not really enough for us:
```
~$ du -sh EmuELEC/build.EmuELEC-Amlogic-ng.aarch64-4/.ccache/
11G     build.EmuELEC-Amlogic-ng.aarch64-4/.ccache/
```

*Both are the ccache size after a totally clean build with limit removed*

Due to this, even during a single build, when the later compilation begins, the ccache already reaches the 10G limit, so the old cache has to be removed, and as the build goes on, old cache goes away one by one.

This effectively makes ccache not used as it intened for re-builds: As we start a new build, the first packages don't have their corresponding cache (since they're removed accroding to ccache's ``LRU (least recently used) strategy`` for removal of the old caches **during the last build**), and since we need to create ccache for these packages, those needed latter in the build are removed **again** due to the LRU strategy. We are effectively chasing the tail of ccache and use almost none of it.

Raising the default limit of ccache to a bigger number here solves the problem of endlessly chasing the tail of ccache, and for future-proof I think 20G is a value that'll be enough for a long time, even if we add more emulators and ports.

**Addtional note** to those who want to mix ccache for multiple devices and even multiple projects (e.g. CE & EE): the ``CCACHE_CACHE_SIZE`` must be set globally and project-independant, as when you build CE with its default ``CCACHE_CACHE_SIZE`` against the cache created by EE, it will think the ccache its full and clean that up, creating your own ccache-chasing-tail issue. E.g. the following setting is what I use for 7different EE builds and 2 different CE builds:
```
CCACHE_DIR="${HOME}/.ccache"
CCACHE_CACHE_SIZE="128G"
```