### PR TITLE
emuelec: add emuelec-utils fun test

### DIFF
--- a/packages/sx05re/emuelec/bin/emuelec-utils
+++ b/packages/sx05re/emuelec/bin/emuelec-utils
@@ -6,6 +6,11 @@
 # Source predefined functions and variables
 . /etc/profile
 
+function test() {
+    echo "success"
+    exit 1
+}
+
 function error() {
     text_viewer /emuelec/logs/emuelec.log -w -t "Error! ${2}" -f 24
 	show_splash.sh exit


### PR DESCRIPTION
On some systems, using busybox bash may disable Emuec-utils, leading to ui bugs. Increase test fun to ensure emulation works

Signed-off-by: ZiHan Huang <zack.huangzihan@outlook.com>