### PR TITLE
auto copy custom bios for psx

### DIFF
--- a/packages/sx05re/emuelec/bin/emuelecRunEmu.sh
+++ b/packages/sx05re/emuelec/bin/emuelecRunEmu.sh
@@ -182,6 +182,23 @@ case ${PLATFORM} in
         fi
 		;;
 	"psx")
+    # get the custom bios name
+    CUSTOMBIOSNAME="${ROMNAME%.*}.bios"
+    if [[ -f "${CUSTOMBIOSNAME}" ]]; then
+        if [[ ! -f "/storage/roms/psx/scph7001.bios" ]]; then
+            # make backup
+            [[ -f "/storage/roms/bios/scph101.bin" ]] && cp "/storage/roms/bios/scph101.bin" "/storage/roms/bios/scph101.bin.bak"
+        fi
+        # use the custom bios
+        cp "${CUSTOMBIOSNAME}" "/storage/roms/bios/scph101.bin"
+    else
+        # recover the original bios
+        if [[ -f "/storage/roms/psx/scph7001.bios" ]]; then
+            cp "/storage/roms/psx/scph7001.bios" "/storage/roms/bios/scph101.bin"
+        else
+            [[ -f "/storage/roms/bios/scph101.bin.bak" ]] && cp "/storage/roms/bios/scph101.bin.bak" "/storage/roms/bios/scph101.bin"
+        fi
+    fi
 		if [ "$EMU" = "duckstation" ]; then
             set_kill_keys "duckstation-nogui"
             RUNTHIS='${TBASH} duckstation.sh "${ROMNAME}"'


### PR DESCRIPTION
for some ps1 games, it has it's own custom bios. you can put custom bios has the same name  on "/storage/roms/<gameromname>.bios", then system will copy it as /storage/bios/scph101.bin into bios dir.In this way, the simulator will load the custom bios(scph101.bin) when it runs. you may also put /storage/roms/psx/scph7001.bios for a common bios for all  other games.