### PR TITLE
RTL8821CU: switch source to 8821cu-20210916

### DIFF
--- a/projects/Amlogic-ce/packages/linux-drivers/RTL8821CU/package.mk
+++ b/projects/Amlogic-ce/packages/linux-drivers/RTL8821CU/package.mk
@@ -2,11 +2,11 @@
 # Copyright (C) 2018-present Team CoreELEC (https://coreelec.org)
 
 PKG_NAME="RTL8821CU"
-PKG_VERSION="a0c18978d1c9ab89f96083354f2c55cf15d483f7"
-PKG_SHA256="de10eadfba30b339a061ea8141459f3e4b7316a0af14726155001d9a145ce2d8"
+PKG_VERSION="e49409f22ceea0d5b5ef431e6170580028b84c9d"
+PKG_SHA256="96737955e76126cc8c9eb88e1e8d874819697d085e8a60894c53893068e89900"
 PKG_LICENSE="GPL"
-PKG_SITE="https://github.com/morrownr/8821cu-20210118"
-PKG_URL="https://github.com/morrownr/8821cu-20210118/archive/$PKG_VERSION.tar.gz"
+PKG_SITE="https://github.com/morrownr/8821cu-20210916"
+PKG_URL="https://github.com/morrownr/8821cu-20210916/archive/$PKG_VERSION.tar.gz"
 PKG_DEPENDS_TARGET="toolchain linux"
 PKG_NEED_UNPACK="$LINUX_DEPENDS"
 PKG_LONGDESC="Realtek RTL8821CU Linux driver"


### PR DESCRIPTION
use commit e49409f22ceea0d5b5ef431e6170580028b84c9d (2023.4.28)

fixes the following build issue due to missing source:

```
builder@rz5 ~/EmuELEC (dev) [2]> ./scripts/get RTL8821CU
GET      RTL8821CU (archive)
--2023-04-30 00:42:45--  https://github.com/morrownr/8821cu-20210118/archive/a0c18978d1c9ab89f96083354f2c55cf15d483f7.tar.gz
Resolving github.com (github.com)... 20.205.243.166
Connecting to github.com (github.com)|20.205.243.166|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2023-04-30 00:42:46 ERROR 404: Not Found.
```