### PR TITLE
poppler: switch source to freedesktop's gitlab

### DIFF
--- a/packages/sx05re/tools/sysutils/poppler/package.mk
+++ b/packages/sx05re/tools/sysutils/poppler/package.mk
@@ -1,25 +1,28 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2019-present Shanti Gilbert (https://github.com/shantigilbert)
+# Copyright (C) 2023-present Guoxin "7Ji" Pu (https://github.com/7Ji)
 
 PKG_NAME="poppler"
-PKG_VERSION="32fa2888eaaaaf80e5d2338cb8cb8b773ccfd4d3"
+PKG_VERSION="23.04.0"
+_PKG_TAG="${PKG_NAME}-${PKG_VERSION}"
+PKG_SHA256="61ab8a8da0ae2bd6f8e7e6f60d5970f7f87cd790c1620f0fe6fbcbdc095c7571"
 PKG_LICENSE="GPL"
-PKG_SITE="https://github.com/freedesktop/poppler"
-PKG_URL="$PKG_SITE.git"
+PKG_SITE="https://gitlab.freedesktop.org/poppler/poppler"
+PKG_URL="${PKG_SITE}/-/archive/${_PKG_TAG}/${PKG_NAME}-${_PKG_TAG}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain zlib libpng libjpeg-turbo boost freetype fontconfig glib glib:host"
 PKG_LONGDESC="The poppler pdf rendering library "
 PKG_TOOLCHAIN="cmake"
 
 
 pre_configure_target() { 
-PKG_CMAKE_OPTS_TARGET="-DCMAKE_BUILD_TYPE=release \
-                       -DENABLE_LIBOPENJPEG=none \
-                       -DENABLE_GLIB=ON \
-                       -DENABLE_QT5=off \
-                       -DENABLE_CPP=off"
-                       
-# Disable "gobject-introspection"
-sed -i "s|set(HAVE_INTROSPECTION \${INTROSPECTION_FOUND})|set(HAVE_INTROSPECTION "NO")|g" ${PKG_BUILD}/CMakeLists.txt
+    PKG_CMAKE_OPTS_TARGET="-DCMAKE_BUILD_TYPE=release \
+                        -DENABLE_LIBOPENJPEG=none \
+                        -DENABLE_GLIB=ON \
+                        -DENABLE_QT5=off \
+                        -DENABLE_CPP=off"
+                        
+    # Disable "gobject-introspection"
+    sed -i "s|set(HAVE_INTROSPECTION \${INTROSPECTION_FOUND})|set(HAVE_INTROSPECTION "NO")|g" ${PKG_BUILD}/CMakeLists.txt
 }
 
 post_makeinstall_target() {


### PR DESCRIPTION
freedesktop.org has set all of its github repos to non-public after migrating its development activity to its own gitlab

this commits updates the source to use the one available on their gitlab site, while also fixed up some formatting. the source is also switched to archive for saner re-builds

fixes the following build issue:

```
builder@rz5 ~/EmuELEC (dev)> ./scripts/get poppler
ProxyChains-3.1 (http://proxychains.sf.net)
GET      poppler (git)
    DELETE      (/home/builder/EmuELEC/sources/poppler/poppler-*/)
    GIT CLONE      poppler
Cloning into '/home/builder/EmuELEC/sources/poppler/poppler-32fa2888eaaaaf80e5d2338cb8cb8b773ccfd4d3'...
Username for 'https://github.com':
```

(the prompt for username appears when there's no requested repo)