### PR TITLE
dosbox-svn: bump to 53ca2f6 (2023.04.08)

### DIFF
--- a/packages/sx05re/libretro/dosbox-svn/package.mk
+++ b/packages/sx05re/libretro/dosbox-svn/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="dosbox-svn"
-PKG_VERSION="c23be7769518d753378307996de35e204d188c63"
+PKG_VERSION="53ca2f6303a652d129321cfc521f000cd7ec5531"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"


### PR DESCRIPTION
the embed_sdl submodule for dosbox-svn was hosted at github.com/fr500/sdl1.2, but the account fr500 was deleted

this bumps dosbox-svn to a newer commit which includes the altered source url for embed_sdl, which is now a no-history repo hosted by JELOS

fixes the following build issue:

```
builder@rz5 ~/EmuELEC (dev) > ./scripts/get dosbox-svn
GET      dosbox-svn (git)
    DELETE      (/home/builder/EmuELEC/sources/dosbox-svn/dosbox-svn-*/)
    GIT CLONE      dosbox-svn
Cloning into '/home/builder/EmuELEC/sources/dosbox-svn/dosbox-svn-c23be7769518d753378307996de35e204d188c63'...
remote: Enumerating objects: 30403, done.
remote: Counting objects: 100% (109/109), done.
remote: Compressing objects: 100% (90/90), done.
remote: Total 30403 (delta 55), reused 41 (delta 17), pack-reused 30294
Receiving objects: 100% (30403/30403), 10.93 MiB | 3.66 MiB/s, done.
Resolving deltas: 100% (24398/24398), done.
HEAD is now at c23be776 Enable inlined memory functions in cpu core
    GIT SUBMODULE      dosbox-svn
Submodule 'libretro/deps/common' (https://github.com/libretro/libretro-common.git) registered for path 'libretro/deps/common'
Submodule 'libretro/deps/embedded_sdl' (https://github.com/fr500/sdl1.2.git) registered for path 'libretro/deps/embedded_sdl'
Submodule 'libretro/deps/sdl' (https://github.com/SDL-mirror/SDL.git) registered for path 'libretro/deps/sdl'
Submodule 'libretro/deps/sdl_net' (https://github.com/SDL-mirror/SDL_net.git) registered for path 'libretro/deps/sdl_net'
Cloning into '/home/builder/EmuELEC/sources/dosbox-svn/dosbox-svn-c23be7769518d753378307996de35e204d188c63/libretro/deps/common'...
Cloning into '/home/builder/EmuELEC/sources/dosbox-svn/dosbox-svn-c23be7769518d753378307996de35e204d188c63/libretro/deps/embedded_sdl'...
Username for 'https://github.com':
```