### PR TITLE
scummvm: bump to b5ca1b3 (2023.04.09)

### DIFF
--- a/packages/sx05re/libretro/scummvm/package.mk
+++ b/packages/sx05re/libretro/scummvm/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="scummvm"
-PKG_VERSION="18add58f142f0b0fe1614f79a9a9cb48aa3eb033"
+PKG_VERSION="b5ca1b340e1a6249997fde8a60f366d039b868b4"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/scummvm"


### PR DESCRIPTION
the old commit is missing due to forced push on scummvm repo

bumps to newest commit as of now to fix the following build issue:

```
builder@rz5 ~/EmuELEC (dev)> ./scripts/get scummvm
GET      scummvm (git)
    DELETE      (/home/builder/EmuELEC/sources/scummvm/scummvm-*/)
    GIT CLONE      scummvm
Cloning into '/home/builder/EmuELEC/sources/scummvm/scummvm-18add58f142f0b0fe1614f79a9a9cb48aa3eb033'...
remote: Enumerating objects: 1170225, done.
remote: Counting objects: 100% (1564/1564), done.
remote: Compressing objects: 100% (572/572), done.
remote: Total 1170225 (delta 1074), reused 1389 (delta 987), pack-reused 1168661
Receiving objects: 100% (1170225/1170225), 1.32 GiB | 14.32 MiB/s, done.
Resolving deltas: 100% (960527/960527), done.
Updating files: 100% (18388/18388), done.
There is no commit '18add58f142f0b0fe1614f79a9a9cb48aa3eb033' on branch 'master' of package 'scummvm'! Aborting!
*********** FAILED COMMAND ***********
. "${get_handler}"
**************************************
```