### PR TITLE
xash3d: remove configure option --disable-vgui

### DIFF
--- a/packages/sx05re/emuelec-ports/xash3d/package.mk
+++ b/packages/sx05re/emuelec-ports/xash3d/package.mk
@@ -19,7 +19,6 @@ cd ${PKG_BUILD}
 	--prefix=/usr \
 	--sdl2=${PKG_ORIG_SYSROOT_PREFIX}/usr \
 	--64bits \
-	--disable-vgui \
 	--disable-gl \
 	--enable-gles2"
   ./waf configure ${ARGS}


### PR DESCRIPTION
the option --disable-vgui was removed from xash3d's configure script, with the option the configure script will break

removed the option and the build issue is fixed