### PR TITLE
inject_bl301: fix PKG_SHA256 and add PKG_ARCH

### DIFF
--- a/projects/Amlogic-ce/devices/Amlogic-ne/packages/sysutils/inject_bl301/package.mk
+++ b/projects/Amlogic-ce/devices/Amlogic-ne/packages/sysutils/inject_bl301/package.mk
@@ -3,7 +3,18 @@
 
 PKG_NAME="inject_bl301"
 PKG_VERSION="fdd519917b8c257ea56cced7e962a2a89f60fb37"
-PKG_SHA256="5be388fd4728b5d44a9f68321aa840bba94b5e050d58a04b77320885f2851281"
+case ${ARCH} in 
+  'arm')
+    PKG_SHA256="5be388fd4728b5d44a9f68321aa840bba94b5e050d58a04b77320885f2851281"
+    ;;
+  'aarch64')
+    PKG_SHA256="04a38b47264cccf2dbdf8f9f1a9606740687d3e30d4d21a02b0845901dcde456"
+    ;;
+  *)
+    PKG_SHA256=''
+    ;;
+esac
+PKG_ARCH="aarch64 arm"
 PKG_SOURCE_NAME="${PKG_NAME}-${ARCH}-${PKG_VERSION}.tar.xz"
 PKG_LICENSE="proprietary"
 PKG_SITE="https://coreelec.org"

--- a/projects/Amlogic-ce/packages/sysutils/inject_bl301/package.mk
+++ b/projects/Amlogic-ce/packages/sysutils/inject_bl301/package.mk
@@ -3,13 +3,18 @@
 
 PKG_NAME="inject_bl301"
 PKG_VERSION="cdaff43a6dc6b44381959bab27b687d6c922b1a0"
-
-if [ ${ARCH} == "arm" ]; then 
-PKG_SHA256="65c3c86fe0068c195de6b0afd2791a479ebd4f563317b553cbeaa9326189f3ec"
-else
-	PKG_SHA256="607be0ec8e0d931803a3c452bae6beccaedb443a1f51177981e14d792c435778" 
-fi
-
+case ${ARCH} in 
+  'arm')
+    PKG_SHA256="65c3c86fe0068c195de6b0afd2791a479ebd4f563317b553cbeaa9326189f3ec"
+    ;;
+  'aarch64')
+    PKG_SHA256="607be0ec8e0d931803a3c452bae6beccaedb443a1f51177981e14d792c435778"
+    ;;
+  *)
+    PKG_SHA256=''
+    ;;
+esac
+PKG_ARCH="aarch64 arm"
 PKG_SOURCE_NAME="$PKG_NAME-$ARCH-$PKG_VERSION.tar.xz"
 PKG_LICENSE="proprietary"
 PKG_SITE="https://coreelec.org"


### PR DESCRIPTION
inject_bl301 only releases compiled binary and its sha256sum is therefore arch-specific, the project Amlogic-ne now introduces a repalce package for it, in which we didn't add arch-specific sha256sum, this results in the following build issue which this commit fixes:

```
GET      inject_bl301 (archive)
--2023-05-02 16:09:32--  https://sources.coreelec.org/inject_bl301-aarch64-fdd519917b8c257ea56cced7e962a2a89f60fb37.tar.xz
Connecting to 192.168.7.17:1081... connected.
Proxy request sent, awaiting response... 200 OK
Length: 1060516 (1.0M) [application/octet-stream]
Saving to: '/home/builder/EmuELEC/sources/inject_bl301/inject_bl301-aarch64-fdd519917b8c257ea56cced7e962a2a89f60fb37.tar.xz'

/home/builder/EmuELEC/sources/inject_bl30 100%[=====================================================================================>]   1.01M  77.8KB/s    in 25s

2023-05-02 16:10:02 (41.9 KB/s) - '/home/builder/EmuELEC/sources/inject_bl301/inject_bl301-aarch64-fdd519917b8c257ea56cced7e962a2a89f60fb37.tar.xz' saved [1060516/1060516]

    WARNING      Incorrect checksum calculated on downloaded file: got 04a38b47264cccf2dbdf8f9f1a9606740687d3e30d4d21a02b0845901dcde456 wanted 5be388fd4728b5d44a9f68321aa840bba94b5e050d58a04b77320885f2851281
--2023-05-02 16:10:02--  http://sources.libreelec.tv/mirror/inject_bl301/inject_bl301-aarch64-fdd519917b8c257ea56cced7e962a2a89f60fb37.tar.xz
Connecting to 192.168.7.17:1081... connected.
Proxy request sent, awaiting response... 301 Moved Permanently
Location: https://sources.libreelec.tv/mirror/inject_bl301/inject_bl301-aarch64-fdd519917b8c257ea56cced7e962a2a89f60fb37.tar.xz [following]
--2023-05-02 16:10:08--  https://sources.libreelec.tv/mirror/inject_bl301/inject_bl301-aarch64-fdd519917b8c257ea56cced7e962a2a89f60fb37.tar.xz
Connecting to 192.168.7.17:1081... connected.
Proxy request sent, awaiting response... 404 Not Found
2023-05-02 16:10:10 ERROR 404: Not Found.

--2023-05-02 16:10:10--  https://sources.coreelec.org/inject_bl301-aarch64-fdd519917b8c257ea56cced7e962a2a89f60fb37.tar.xz
Connecting to 192.168.7.17:1081... connected.
Proxy request sent, awaiting response... 200 OK
Length: 1060516 (1.0M) [application/octet-stream]
Saving to: '/home/builder/EmuELEC/sources/inject_bl301/inject_bl301-aarch64-fdd519917b8c257ea56cced7e962a2a89f60fb37.tar.xz'

/home/builder/EmuELEC/sources/inject_bl30 100%[=====================================================================================>]   1.01M   141KB/s    in 7.2s

2023-05-02 16:10:23 (143 KB/s) - '/home/builder/EmuELEC/sources/inject_bl301/inject_bl301-aarch64-fdd519917b8c257ea56cced7e962a2a89f60fb37.tar.xz' saved [1060516/1060516]

    WARNING      Incorrect checksum calculated on downloaded file: got 04a38b47264cccf2dbdf8f9f1a9606740687d3e30d4d21a02b0845901dcde456 wanted 5be388fd4728b5d44a9f68321aa840bba94b5e050d58a04b77320885f2851281
--2023-05-02 16:10:23--  http://sources.libreelec.tv/mirror/inject_bl301/inject_bl301-aarch64-fdd519917b8c257ea56cced7e962a2a89f60fb37.tar.xz
Connecting to 192.168.7.17:1081... connected.
Proxy request sent, awaiting response... 301 Moved Permanently
Location: https://sources.libreelec.tv/mirror/inject_bl301/inject_bl301-aarch64-fdd519917b8c257ea56cced7e962a2a89f60fb37.tar.xz [following]
--2023-05-02 16:10:23--  https://sources.libreelec.tv/mirror/inject_bl301/inject_bl301-aarch64-fdd519917b8c257ea56cced7e962a2a89f60fb37.tar.xz
Connecting to 192.168.7.17:1081... connected.
Proxy request sent, awaiting response... 404 Not Found
2023-05-02 16:10:25 ERROR 404: Not Found.

Cannot get inject_bl301 sources : https://sources.coreelec.org/inject_bl301-aarch64-fdd519917b8c257ea56cced7e962a2a89f60fb37.tar.xz
Try later!
*********** FAILED COMMAND ***********
. "${get_handler}"
**************************************
```

also add PKG_ARCH since the package is only released for arm and aarch64