### PR TITLE
lib32-opengl-meson: support Amlogic-ne

### DIFF
--- a/projects/Amlogic-ce/devices/Amlogic-ne/packages/opengl-meson/scripts/libmali-overlay-setup
+++ b/projects/Amlogic-ce/devices/Amlogic-ne/packages/opengl-meson/scripts/libmali-overlay-setup
@@ -2,9 +2,11 @@
 
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2018-present Team CoreELEC (https://coreelec.org)
-
+mkdir -p /var/lib32
 if grep -qE "sm1|sc2|s4" /proc/device-tree/compatible; then
     ln -sf /usr/lib/libMali.dvalin.so /var/lib/libMali.so
+    ln -sf /usr/lib32/libMali.dvalin.so /var/lib/libMali.so
 elif grep -q "t7" /proc/device-tree/compatible; then
     ln -sf /usr/lib/libMali.gondul.so /var/lib/libMali.so
+    ln -sf /usr/lib32/libMali.gondul.so /var/lib/libMali.so
 fi


### PR DESCRIPTION
also reformats the code

does not need to be merged after #1184 , as this modifies another part of Amlogic-ne/opengl-meson, but for packages depending on opengl-meson to build successfully #1184 is essential while this is optional. Only with #1184 could you proceed to the part where this fix is essential.