### PR TITLE
[EE - Emulator][FbNeoSA] Adds DPAD hats assignments by default.

### DIFF
--- a/packages/sx05re/emulators/fbneoSA/scripts/fbneo.sh
+++ b/packages/sx05re/emulators/fbneoSA/scripts/fbneo.sh
@@ -6,7 +6,21 @@
 # Source predefined functions and variables
 . /etc/profile
 
-mkdir -p /emuelec/configs/fbneo
+add_player_hat() 
+{
+    local pl=$1
+    local pf="/storage/.local/share/fbneo/config/p${pl}defaults.ini"
+
+    if [ ! -f "${pf}" ]; then
+      echo "version 0x100003" > ${pf}
+      echo "macro \"P${pl} Up\" switch 0x4012" >> ${pf}
+      echo "macro \"P${pl} Down\" switch 0x4013" >> ${pf}
+      echo "macro \"P${pl} Left\" switch 0x4010" >> ${pf}
+      echo "macro \"P${pl} Right\" switch 0x4011" >> ${pf}
+    fi
+}
+
+mkdir -p /emuelec/configs/fbneo/config
 mkdir -p /storage/.local/share
 
 if [ -d "/storage/.local/share/fbneo/" ]; then
@@ -18,6 +32,11 @@ fi
 if [ ! -L "/storage/.local/share/fbneo" ]; then
     ln -sf /emuelec/configs/fbneo /storage/.local/share/fbneo
 fi
+
+add_player_hat 1
+add_player_hat 2
+add_player_hat 3
+add_player_hat 4
 
 # TODO: Allow settings from ES 
 #case "$@" in


### PR DESCRIPTION
initial commit - add dpad hats to work like the analog controller by default.