### PR TITLE
opengl-meson: fix lib32 mali symlinks for Amlogic-ne

### DIFF
--- a/projects/Amlogic-ce/devices/Amlogic-ne/packages/opengl-meson/scripts/libmali-overlay-setup
+++ b/projects/Amlogic-ce/devices/Amlogic-ne/packages/opengl-meson/scripts/libmali-overlay-setup
@@ -5,8 +5,8 @@
 mkdir -p /var/lib32
 if grep -qE "sm1|sc2|s4" /proc/device-tree/compatible; then
     ln -sf /usr/lib/libMali.dvalin.so /var/lib/libMali.so
-    ln -sf /usr/lib32/libMali.dvalin.so /var/lib/libMali.so
+    ln -sf /usr/lib32/libMali.dvalin.so /var/lib32/libMali.so
 elif grep -q "t7" /proc/device-tree/compatible; then
     ln -sf /usr/lib/libMali.gondul.so /var/lib/libMali.so
-    ln -sf /usr/lib32/libMali.gondul.so /var/lib/libMali.so
+    ln -sf /usr/lib32/libMali.gondul.so /var/lib32/libMali.so
 fi


### PR DESCRIPTION
the libmali-overlay-setup script in the package for Amlogic-ne does not set up the symlinks for libmali properly, which replaces the link for 64bit one with the 32bit one

this will result in utterly wrong lookup result when any application tries to load libEGL/libGL/etc at runtime, which will pick up the 32bit libmali over the 64bit one and cannot run at all

should solve one of the problem mentioned in the following forum post:

https://emuelec.discourse.group/t/trying-to-compile-for-s905w2-amlogic-ne/2013

quote @compusat22:
> I’m trying to compile a version of emuelec for the S905w2 but after creating image I got it to boot but Emulationstation isn’t running due to "emulationstation: error while loading shared libraries: libEGL.so: wrong ELF class: ELFCLASS32