### PR TITLE
Amlogic-ne: fix cfgload

### DIFF
--- a/projects/Amlogic-ce/devices/Amlogic-ne/bootloader/scripts/Generic_cfgload.src
+++ b/projects/Amlogic-ce/devices/Amlogic-ne/bootloader/scripts/Generic_cfgload.src
@@ -1,4 +1,4 @@
-echo "Using device ${device}, number ${devnr}, partition ${partnr}, CoreELEC on eMMC: ${ce_on_emmc}"
+echo "Using device ${device}, number ${devnr}, partition ${partnr}, EmuELEC on eMMC: ${ce_on_emmc}"
 
 setenv remotewakeup "0xffffffff"
 setenv decode_type "0"
@@ -8,7 +8,7 @@ setenv vout "1080p60hz"
 setenv frac_rate_policy "0"
 setenv consoleopt "console=tty0 no_console_suspend"
 
-setenv rootopt "BOOT_IMAGE=kernel.img boot=LABEL=COREELEC disk=LABEL=STORAGE"
+setenv rootopt "BOOT_IMAGE=kernel.img boot=LABEL=EMUELEC disk=LABEL=STORAGE"
 if test "${ce_on_emmc}" = "yes"; then setenv rootopt "BOOT_IMAGE=kernel.img boot=LABEL=CE_FLASH disk=FOLDER=/dev/CE_STORAGE"; fi
 
 if fatload ${device} ${devnr}:${partnr} ${loadaddr} resolution.ini; then env import -t ${loadaddr} ${filesize}; fi


### PR DESCRIPTION
the current Generic_cfgload.src is kept the same as the one in CE, however this means the fs label is not right for our bootup setup.

we're using `EmuELEC` as the fs label for the first partition on disk, instead of `CoreELEC`. If kept the same the image won't boot, changing that to `EmuELEC` instead.

should solve one of the problems mentioned in the following forum post:

https://emuelec.discourse.group/t/trying-to-compile-for-s905w2-amlogic-ne/2013

quote @compusat22:
> first time it booted it fell over as it couldnt mount (coreelec partition)
> changed the AML_autoscript and cfgload from a prebuilt Amlogic-ng image. (as I think it was using ones from coreelec build)