### PR TITLE
Fix apache-ant version, 1.10.13

### DIFF
--- a/packages/addons/addon-depends/jre-depends/apache-ant/package.mk
+++ b/packages/addons/addon-depends/jre-depends/apache-ant/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="apache-ant"
-PKG_VERSION="1.10.12"
-PKG_SHA256="6115c940367e50755cf806de5816f20a1db1321b1cb734e2c34ab20ef6682b9b"
+PKG_VERSION="1.10.13"
+PKG_SHA256="de0a860bf339e6975558f426772a6aa2c6ae0856215dd9aaf57aa2476d665664"
 PKG_LICENSE="Apache License 2.0"
 PKG_SITE="https://ant.apache.org/"
 PKG_URL="https://downloads.apache.org/ant/binaries/${PKG_NAME}-${PKG_VERSION}-bin.tar.xz"


### PR DESCRIPTION
Fix apache-ant version, 1.10.12 doesn't exist on https://downloads.apache.org/ant/binaries/ anymore, will cause compile error.
Upgrade to version 1.10.13, Tested.