### PR TITLE
Updated SDL2_mixer 32 bit and 64

### DIFF
--- a/packages/lib32/audio/lib32-SDL2_mixer/package.mk
+++ b/packages/lib32/audio/lib32-SDL2_mixer/package.mk
@@ -3,15 +3,13 @@
 # Copyright (C) 2022-present 7Ji (https://github.com/7Ji)
 
 PKG_NAME="lib32-SDL2_mixer"
-PKG_VERSION="$(get_pkg_version SDL2_mixer)"
-PKG_NEED_UNPACK="$(get_pkg_directory SDL2_mixer)"
+PKG_VERSION="2.0.4"
 PKG_ARCH="aarch64"
 PKG_LICENSE="GPLv3"
 PKG_SITE="http://www.libsdl.org/projects/SDL_mixer/release"
-PKG_URL=""
+PKG_URL="$PKG_SITE/SDL2_mixer-$PKG_VERSION.tar.gz"
 PKG_DEPENDS_TARGET="lib32-toolchain lib32-alsa-lib lib32-SDL2 lib32-mpg123-compat lib32-libvorbis lib32-libvorbisidec lib32-libogg lib32-opusfile lib32-libmodplug lib32-flac"
-PKG_PATCH_DIRS+=" $(get_pkg_directory SDL2_mixer)/patches"
-PKG_LONGDESC="SDL_mixer 2.0.1"
+PKG_LONGDESC="SDL_mixer 2.0.4"
 PKG_BUILD_FLAGS="lib32"
 
 PKG_CONFIGURE_OPTS_TARGET="--disable-sdltest \
@@ -21,12 +19,6 @@ PKG_CONFIGURE_OPTS_TARGET="--disable-sdltest \
                            --enable-music-ogg-tremor \
                            --enable-music-ogg \
                            --enable-music-mp3"
-
-unpack() {
-  ${SCRIPTS}/get SDL2_mixer
-  mkdir -p ${PKG_BUILD}
-  tar --strip-components=1 -xf ${SOURCES}/SDL2_mixer/SDL2_mixer-${PKG_VERSION}.tar.gz -C ${PKG_BUILD}
-}
 
 post_makeinstall_target() {
   safe_remove ${INSTALL}/usr/include

--- a/packages/lib32/audio/lib32-SDL2_mixer/package.mk
+++ b/packages/lib32/audio/lib32-SDL2_mixer/package.mk
@@ -4,6 +4,7 @@
 
 PKG_NAME="lib32-SDL2_mixer"
 PKG_VERSION="2.0.4"
+PKG_SHA256="b4cf5a382c061cd75081cf246c2aa2f9df8db04bdda8dcdc6b6cca55bede2419"
 PKG_ARCH="aarch64"
 PKG_LICENSE="GPLv3"
 PKG_SITE="http://www.libsdl.org/projects/SDL_mixer/release"

--- a/packages/sx05re/tools/SDL2/SDL2_mixer/package.mk
+++ b/packages/sx05re/tools/SDL2/SDL2_mixer/package.mk
@@ -2,13 +2,13 @@
 # Copyright (C) 2019-present Team CoreELEC (https://coreelec.org)
 
 PKG_NAME="SDL2_mixer"
-PKG_VERSION="2.6.3"
-PKG_SHA256="7a6ba86a478648ce617e3a5e9277181bc67f7ce9876605eea6affd4a0d6eea8f"
+PKG_VERSION="d79638a1b6ff6563a82b57732ce05ca27cc54338"
+PKG_GIT_CLONE_BRANCH="SDL2"
 PKG_LICENSE="GPLv3"
-PKG_SITE="http://www.libsdl.org/projects/SDL_mixer/release"
-PKG_URL="$PKG_SITE/$PKG_NAME-$PKG_VERSION.tar.gz"
+PKG_SITE="https://github.com/libsdl-org/SDL_mixer"
+PKG_URL="$PKG_SITE.git"
 PKG_DEPENDS_TARGET="toolchain alsa-lib SDL2 mpg123-compat libvorbis libvorbisidec libogg opusfile libmodplug flac"
-PKG_LONGDESC="SDL2 mixer 2.6.3"
+PKG_LONGDESC="An audio mixer that supports various file formats for Simple Directmedia Layer. "
 PKG_DEPENDS_HOST="toolchain:host SDL2:host"
 
 pre_configure_host() {
@@ -35,4 +35,3 @@ PKG_CMAKE_OPTS_TARGET="-DSDL2MIXER_MIDI_FLUIDSYNTH=OFF \
                        -DSDL2MIXER_MOD_XMP=OFF \
                        -DSDL2MIXER_WAVPACK=OFF"
 }
-

--- a/packages/sx05re/tools/SDL2/SDL2_mixer/package.mk
+++ b/packages/sx05re/tools/SDL2/SDL2_mixer/package.mk
@@ -7,8 +7,8 @@ PKG_SHA256="7a6ba86a478648ce617e3a5e9277181bc67f7ce9876605eea6affd4a0d6eea8f"
 PKG_LICENSE="GPLv3"
 PKG_SITE="http://www.libsdl.org/projects/SDL_mixer/release"
 PKG_URL="$PKG_SITE/$PKG_NAME-$PKG_VERSION.tar.gz"
-PKG_DEPENDS_TARGET="toolchain alsa-lib SDL2 mpg123-compat libvorbis libvorbisidec libogg opusfile libmodplug flac fluidsynth"
-PKG_LONGDESC="SDL2 mixer"
+PKG_DEPENDS_TARGET="toolchain alsa-lib SDL2 mpg123-compat libvorbis libvorbisidec libogg opusfile libmodplug flac"
+PKG_LONGDESC="SDL2 mixer 2.6.3"
 PKG_DEPENDS_HOST="toolchain:host SDL2:host"
 
 pre_configure_host() {

--- a/packages/sx05re/tools/SDL2/SDL2_mixer/package.mk
+++ b/packages/sx05re/tools/SDL2/SDL2_mixer/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="SDL2_mixer"
 PKG_VERSION="2.6.3"
-PKG_SHA256=""
+PKG_SHA256="7a6ba86a478648ce617e3a5e9277181bc67f7ce9876605eea6affd4a0d6eea8f"
 PKG_LICENSE="GPLv3"
 PKG_SITE="http://www.libsdl.org/projects/SDL_mixer/release"
 PKG_URL="$PKG_SITE/$PKG_NAME-$PKG_VERSION.tar.gz"
@@ -18,12 +18,13 @@ pre_configure_host() {
                        -DSDL2MIXER_FLAC=OFF \
                        -DSDL2MIXER_MIDI=OFF \
                        -DSDL2MIXER_VORBIS=OFF \
-                       -DSDL2MIXER_OGG=OFF"
+                       -DSDL2MIXER_OGG=OFF \
+                       -DSDL2MIXER_MOD_XMP=OFF \
+                       -DSDL2MIXER_WAVPACK=OFF"
 }
 
 pre_configure_target() {
-  SDL2_CONFIG=${SYSROOT_PREFIX}/usr/bin/sdl2-config
-  PKG_CMAKE_OPTS_TARGET="-DSDL2MIXER_MIDI_FLUIDSYNTH=OFF \
+PKG_CMAKE_OPTS_TARGET="-DSDL2MIXER_MIDI_FLUIDSYNTH=OFF \
                        -DSDL2MIXER_FLAC=ON \
                        -DSDL2MIXER_MOD_MODPLUG=ON \
                        -DSDL2MIXER_VORBIS_TREMOR=ON \

--- a/packages/sx05re/tools/SDL2/SDL2_mixer/package.mk
+++ b/packages/sx05re/tools/SDL2/SDL2_mixer/package.mk
@@ -2,22 +2,36 @@
 # Copyright (C) 2019-present Team CoreELEC (https://coreelec.org)
 
 PKG_NAME="SDL2_mixer"
-PKG_VERSION="2.0.4"
+PKG_VERSION="2.6.3"
 PKG_SHA256=""
 PKG_LICENSE="GPLv3"
 PKG_SITE="http://www.libsdl.org/projects/SDL_mixer/release"
 PKG_URL="$PKG_SITE/$PKG_NAME-$PKG_VERSION.tar.gz"
-PKG_DEPENDS_TARGET="toolchain alsa-lib SDL2 mpg123-compat libvorbis libvorbisidec libogg opusfile libmodplug flac"
-PKG_LONGDESC="SDL_mixer 2.0.1"
+PKG_DEPENDS_TARGET="toolchain alsa-lib SDL2 mpg123-compat libvorbis libvorbisidec libogg opusfile libmodplug flac fluidsynth"
+PKG_LONGDESC="SDL2 mixer"
 PKG_DEPENDS_HOST="toolchain:host SDL2:host"
 
-pre_configure_target() {
-
-  PKG_CONFIGURE_OPTS_TARGET="--disable-sdltest \
-							 --disable-music-midi-fluidsynth \
-							 --enable-music-flac \
-							 --enable-music-mod-modplug \
-							 --enable-music-ogg-tremor \
-							 --enable-music-ogg \
-							 --enable-music-mp3"
+pre_configure_host() {
+  PKG_CMAKE_OPTS_HOST="-DSDL2MIXER_OPUS=OFF \
+                       -DSDL2MIXER_MOD=OFF \
+                       -DSDL2MIXER_MP3=OFF \
+                       -DSDL2MIXER_FLAC=OFF \
+                       -DSDL2MIXER_MIDI=OFF \
+                       -DSDL2MIXER_VORBIS=OFF \
+                       -DSDL2MIXER_OGG=OFF"
 }
+
+pre_configure_target() {
+  SDL2_CONFIG=${SYSROOT_PREFIX}/usr/bin/sdl2-config
+  PKG_CMAKE_OPTS_TARGET="-DSDL2MIXER_MIDI_FLUIDSYNTH=OFF \
+                       -DSDL2MIXER_FLAC=ON \
+                       -DSDL2MIXER_MOD_MODPLUG=ON \
+                       -DSDL2MIXER_VORBIS_TREMOR=ON \
+                       -DSDL2MIXER_OGG=ON \
+                       -DSDL2MIXER_MP3=ON \
+                       -DSDL2MIXER_SAMPLES=OFF \
+                       -DSDL2MIXER_MOD_MODPLUG_SHARED=OFF \
+                       -DSDL2MIXER_MOD_XMP=OFF \
+                       -DSDL2MIXER_WAVPACK=OFF"
+}
+


### PR DESCRIPTION
Updated SDL2_mixer 32 bit not to depend from 64 bit package version to let SORR works.
Updated SDL2_mixer 64 bit to latest update to enable CDOGs