### PR TITLE
System updates 4.7

### DIFF
--- a/packages/linux-firmware/kernel-firmware/package.mk
+++ b/packages/linux-firmware/kernel-firmware/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kernel-firmware"
-PKG_VERSION="20230919"
-PKG_SHA256="97fada0d02bdafc4e017a4dcc456e7fa48bc8daf2ddf75161f39a92e38f084ad"
+PKG_VERSION="20231111"
+PKG_SHA256="8d4959c1293ff8a6e40ac3d265205297a3e93e4fe5e8e25a7d16cfed78cbb098"
 PKG_LICENSE="other"
 PKG_SITE="https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/"
 PKG_URL="https://cdn.kernel.org/pub/linux/kernel/firmware/linux-firmware-${PKG_VERSION}.tar.xz"

--- a/packages/multimedia/SDL2/package.mk
+++ b/packages/multimedia/SDL2/package.mk
@@ -4,8 +4,8 @@
 # Copyright (C) 2022-present 7Ji (https://github.com/7Ji)
 
 PKG_NAME="SDL2"
-PKG_VERSION="2.28.3"
-PKG_SHA256="7acb8679652701a2504d734e2ba7543ec1a83e310498ddd22fd44bf965eb5518"
+PKG_VERSION="2.28.5"
+PKG_SHA256="332cb37d0be20cb9541739c61f79bae5a477427d79ae85e352089afdaf6666e4"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.libsdl.org/"
 PKG_URL="https://www.libsdl.org/release/SDL2-${PKG_VERSION}.tar.gz"

--- a/packages/sx05re/emuelec-emulationstation/config/es_systems.cfg
+++ b/packages/sx05re/emuelec-emulationstation/config/es_systems.cfg
@@ -118,6 +118,25 @@ This file will be replaced on any new update of EmuELEC-->
 		</emulators>
 	</system>
 	<system>
+		<name>fmtmarty</name>
+		<fullname>FM Towns</fullname>
+		<manufacturer>Fujitsu</manufacturer>
+		<release>1989</release>
+		<hardware>computer</hardware>
+		<path>/storage/roms/mame/fmtownsux</path>
+ 		<extension>.cmd</extension>
+		<command>emuelecRunEmu.sh %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers="%CONTROLLERSCONFIG%"</command>
+		<platform>fmtmarty</platform>
+		<theme>fmtmarty</theme>
+		<emulators>
+			<emulator name="libretro">
+				<cores>
+					<core default="true">mame</core>
+				</cores>
+			</emulator>
+		</emulators>
+	</system>
+	<system>
 		<name>atari2600</name>
 		<fullname>Atari 2600</fullname>
 		<manufacturer>Atari</manufacturer>

--- a/packages/sx05re/emuelec-emulationstation/themes/Crystal/package.mk
+++ b/packages/sx05re/emuelec-emulationstation/themes/Crystal/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2020-present Shanti Gilbert (https://github.com/shantigilbert)
 
 PKG_NAME="Crystal"
-PKG_VERSION="43f80b3972f98cb67a61713d9cd83255dec0ee97"
+PKG_VERSION="fa6935ff6cca613f51b28c31e700ab5133a2934b"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/sx05re/emuelec/tmpfiles.d/emuelec-dirs.conf
+++ b/packages/sx05re/emuelec/tmpfiles.d/emuelec-dirs.conf
@@ -71,6 +71,7 @@ d    /storage/roms/genh                 0777 root root - -
 d    /storage/roms/gw                   0777 root root - -
 d    /storage/roms/intellivision        0777 root root - -
 d    /storage/roms/mame                 0777 root root - -
+d    /storage/roms/mame/fmtownsux	0777 root root - -
 d    /storage/roms/mastersystem         0777 root root - -
 d    /storage/roms/megadrive            0777 root root - -
 d    /storage/roms/megadrive-japan      0777 root root - -


### PR DESCRIPTION
Updated kernel to latest one 20231111
Updated SDL2 to 2.28.5 removed the TMNT patch as it is not needed anymore.
Added fmtowns theme and dir.
