### PR TITLE
Update retroarch fix audio amlogic old

### DIFF
--- a/packages/sx05re/libretro/retroarch/patches/Amlogic-old/01-ALSA_fix.patch
+++ b/packages/sx05re/libretro/retroarch/patches/Amlogic-old/01-ALSA_fix.patch
@@ -1,0 +1,38 @@
+diff --git a/audio/common/alsa.c b/audio/common/alsa.c
+index f1b011a2e8..07a3d9b23b 100644
+--- a/audio/common/alsa.c
++++ b/audio/common/alsa.c
+@@ -63,16 +63,6 @@ int alsa_init_pcm(snd_pcm_t **pcm,
+       goto error;
+    }
+ 
+-   if ((errnum = snd_pcm_hw_params_any(*pcm, params)) < 0)
+-   {
+-      RARCH_ERR("[ALSA]: Failed to query hardware parameters from %s device \"%s\": %s\n",
+-            snd_pcm_stream_name(stream),
+-            snd_pcm_name(*pcm),
+-            snd_strerror(errnum));
+-
+-      goto error;
+-   }
+-
+    format = (snd_pcm_hw_params_test_format(*pcm, params, SND_PCM_FORMAT_FLOAT) == 0)
+          ? SND_PCM_FORMAT_FLOAT : SND_PCM_FORMAT_S16;
+    stream_info->has_float = (format == SND_PCM_FORMAT_FLOAT);
+@@ -83,6 +73,16 @@ int alsa_init_pcm(snd_pcm_t **pcm,
+          snd_pcm_name(*pcm)
+    );
+ 
++   if ((errnum = snd_pcm_hw_params_any(*pcm, params)) < 0)
++   {
++      RARCH_ERR("[ALSA]: Failed to query hardware parameters from %s device \"%s\": %s\n",
++            snd_pcm_stream_name(stream),
++            snd_pcm_name(*pcm),
++            snd_strerror(errnum));
++
++      goto error;
++   }
++
+    if ((errnum = snd_pcm_hw_params_set_access(*pcm, params, SND_PCM_ACCESS_RW_INTERLEAVED)) < 0)
+    {
+       RARCH_ERR("[ALSA]: Failed to set %s access for %s device \"%s\": %s\n",


### PR DESCRIPTION
I'm working on my own build and found out there is no sound on recent version of RetroArch when building for Amlogic-old platform.

I made a patch file and confirmed it working on my S905L SOC. I don't have any other board to test this on tho...

I updated RetroArch commit id to tag v1.16.0.3 while at it!