### PR TITLE
EE - setres.sh - 480cvbs 576cvbs default fix

### DIFF
--- a/packages/sx05re/emuelec/bin/setres.sh
+++ b/packages/sx05re/emuelec/bin/setres.sh
@@ -228,7 +228,7 @@ COUNT_ARGS=${#CUSTOM_OFFSETS[@]}
 if [[ "$MODE" == *"cvbs" ]]; then
   if [[ "$COUNT_ARGS" == "0" ]]; then
     [[ "$MODE" == "480cvbs" ]] && CUSTOM_OFFSETS="30 10 669 469"
-    [[ "$MODE" == "576cvbs" ]] && CUSTOM_OFFSETS="5 13"
+    [[ "$MODE" == "576cvbs" ]] && CUSTOM_OFFSETS="35 20 680 565"
   fi
 fi
 

--- a/packages/sx05re/emuelec/bin/setres.sh
+++ b/packages/sx05re/emuelec/bin/setres.sh
@@ -225,7 +225,7 @@ fi
 # Now that the primary buffer has been acquired we blank it again because the new
 # memory allocated, may contain garbage artifact data.
 COUNT_ARGS=${#CUSTOM_OFFSETS[@]}
-if [[ "$MODE" == *"cvbs" ]]; then
+if [[ -z "${OFFSET_SETTING}" ]] && [[ "$MODE" == *"cvbs" ]]; then
   if [[ "$COUNT_ARGS" == "0" ]]; then
     [[ "$MODE" == "480cvbs" ]] && CUSTOM_OFFSETS="30 10 669 469"
     [[ "$MODE" == "576cvbs" ]] && CUSTOM_OFFSETS="35 20 680 565"

--- a/packages/sx05re/emuelec/bin/setres.sh
+++ b/packages/sx05re/emuelec/bin/setres.sh
@@ -227,7 +227,7 @@ fi
 COUNT_ARGS=${#CUSTOM_OFFSETS[@]}
 if [[ "$MODE" == *"cvbs" ]]; then
   if [[ "$COUNT_ARGS" == "0" ]]; then
-    [[ "$MODE" == "480cvbs" ]] && CUSTOM_OFFSETS="5 13"
+    [[ "$MODE" == "480cvbs" ]] && CUSTOM_OFFSETS="30 10 669 469"
     [[ "$MODE" == "576cvbs" ]] && CUSTOM_OFFSETS="5 13"
   fi
 fi


### PR DESCRIPTION
EE - setres.sh - 480cvbs 576cvbs default values fix

Default settings fix for 480cvbs. Based on the values for earlier EE versions.

**Testing Procedure:**
Login to SSH, type the following commands:
```
cd /emuelec/bin
wget https://raw.githubusercontent.com/EmuELEC/EmuELEC/72046f93172828167a2aa9c310b9bd969b81cc53/packages/sx05re/emuelec/bin/setres.sh
chmod +x setres.sh
```
reboot.
