### PR TITLE
EE - Retroarch - Adjust Default Configuration.

### DIFF
--- a/packages/sx05re/libretro/retroarch/package.mk
+++ b/packages/sx05re/libretro/retroarch/package.mk
@@ -164,7 +164,7 @@ fi
   sed -i -e "s/# joypad_autoconfig_dir =/joypad_autoconfig_dir = \/tmp\/joypads/" $INSTALL/etc/retroarch.cfg
   sed -i -e "s/# input_remapping_directory =/input_remapping_directory = \/storage\/.config\/retroarch\/config\/remappings/" $INSTALL/etc/retroarch.cfg
   sed -i -e "s/# input_menu_toggle_gamepad_combo = 0/input_menu_toggle_gamepad_combo = 2/" $INSTALL/etc/retroarch.cfg
-	sed -i -e "s/# input_quit_gamepad_combo = 0/input_quit_gamepad_combo = 4/" $INSTALL/etc/retroarch.cfg
+	sed -i -e "s/# input_quit_gamepad_combo = 0/input_quit_gamepad_combo = 8/" $INSTALL/etc/retroarch.cfg
   sed -i -e "s/# all_users_control_menu = false/all_users_control_menu = true/" $INSTALL/etc/retroarch.cfg
 
   # Menu

--- a/packages/sx05re/libretro/retroarch/package.mk
+++ b/packages/sx05re/libretro/retroarch/package.mk
@@ -164,6 +164,7 @@ fi
   sed -i -e "s/# joypad_autoconfig_dir =/joypad_autoconfig_dir = \/tmp\/joypads/" $INSTALL/etc/retroarch.cfg
   sed -i -e "s/# input_remapping_directory =/input_remapping_directory = \/storage\/.config\/retroarch\/config\/remappings/" $INSTALL/etc/retroarch.cfg
   sed -i -e "s/# input_menu_toggle_gamepad_combo = 0/input_menu_toggle_gamepad_combo = 2/" $INSTALL/etc/retroarch.cfg
+	sed -i -e "s/# input_quit_gamepad_combo = 0/input_quit_gamepad_combo = 4/" $INSTALL/etc/retroarch.cfg
   sed -i -e "s/# all_users_control_menu = false/all_users_control_menu = true/" $INSTALL/etc/retroarch.cfg
 
   # Menu

--- a/packages/sx05re/libretro/retroarch/package.mk
+++ b/packages/sx05re/libretro/retroarch/package.mk
@@ -163,8 +163,8 @@ fi
   sed -i -e "s/# input_autodetect_enable = true/input_autodetect_enable = true/" $INSTALL/etc/retroarch.cfg
   sed -i -e "s/# joypad_autoconfig_dir =/joypad_autoconfig_dir = \/tmp\/joypads/" $INSTALL/etc/retroarch.cfg
   sed -i -e "s/# input_remapping_directory =/input_remapping_directory = \/storage\/.config\/retroarch\/config\/remappings/" $INSTALL/etc/retroarch.cfg
-  sed -i -e "s/# input_menu_toggle_gamepad_combo = 0/input_menu_toggle_gamepad_combo = 2/" $INSTALL/etc/retroarch.cfg
-	sed -i -e "s/# input_quit_gamepad_combo = 0/input_quit_gamepad_combo = 8/" $INSTALL/etc/retroarch.cfg
+  sed -i -e "s/# input_menu_toggle_gamepad_combo = 0/input_menu_toggle_gamepad_combo = 8/" $INSTALL/etc/retroarch.cfg
+	sed -i -e "s/# input_quit_gamepad_combo = 0/input_quit_gamepad_combo = 4/" $INSTALL/etc/retroarch.cfg
   sed -i -e "s/# all_users_control_menu = false/all_users_control_menu = true/" $INSTALL/etc/retroarch.cfg
 
   # Menu


### PR DESCRIPTION
EE - Retroarch - Adjust Default Configuration.

1. Currently Retroarch does not define any quit buttons. The change is so Retroarch will by default use SELECT+START to quit. Currently value "0" means it's not set at all. Changing it to "8" is SELECT+START. (input_quit_gamepad_combo)

2. Retroarch input menu was L3+R3, however some do not have these buttons assigned at all. Change from Value "2" to "8" is to hold the select button for 2 seconds to get into the menu by default. (input_menu_toggle_gamepad_combo)

