### PR TITLE
Resetup fmtowns

### DIFF
--- a/packages/sx05re/emuelec-emulationstation/config/es_systems.cfg
+++ b/packages/sx05re/emuelec-emulationstation/config/es_systems.cfg
@@ -74,7 +74,6 @@ This file will be replaced on any new update of EmuELEC-->
 					<core>fbneo</core>
 					<core>fbalpha2012</core>
 					<core>mame2016</core>
-					<core>mame</core>
 				</cores>
 			</emulator>
 			<emulator name="FBNEOSA">

--- a/packages/sx05re/emuelec-emulationstation/config/es_systems.cfg
+++ b/packages/sx05re/emuelec-emulationstation/config/es_systems.cfg
@@ -123,7 +123,7 @@ This file will be replaced on any new update of EmuELEC-->
 		<manufacturer>Fujitsu</manufacturer>
 		<release>1989</release>
 		<hardware>computer</hardware>
-		<path>/storage/roms/mame/fmtownsux</path>
+		<path>/storage/roms/fmtownsux</path>
  		<extension>.cmd</extension>
 		<command>emuelecRunEmu.sh %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers="%CONTROLLERSCONFIG%"</command>
 		<platform>fmtmarty</platform>
@@ -131,7 +131,7 @@ This file will be replaced on any new update of EmuELEC-->
 		<emulators>
 			<emulator name="libretro">
 				<cores>
-					<core default="true">mame</core>
+					<core default="true">fmtowns</core>
 				</cores>
 			</emulator>
 		</emulators>

--- a/packages/sx05re/emuelec/tmpfiles.d/emuelec-dirs.conf
+++ b/packages/sx05re/emuelec/tmpfiles.d/emuelec-dirs.conf
@@ -56,6 +56,7 @@ d    /storage/roms/fbneo/sgx            0777 root root - -
 d    /storage/roms/fbneo/sms            0777 root root - -
 d    /storage/roms/fbneo/tg16           0777 root root - -
 d    /storage/roms/fds                  0777 root root - -
+d    /storage/roms/fmtownsux		0777 root root - -
 d    /storage/roms/freej2me             0777 root root - -
 d    /storage/roms/gameandwatch         0777 root root - -
 d    /storage/roms/gamegear             0777 root root - -
@@ -71,7 +72,6 @@ d    /storage/roms/genh                 0777 root root - -
 d    /storage/roms/gw                   0777 root root - -
 d    /storage/roms/intellivision        0777 root root - -
 d    /storage/roms/mame                 0777 root root - -
-d    /storage/roms/mame/fmtownsux	0777 root root - -
 d    /storage/roms/mastersystem         0777 root root - -
 d    /storage/roms/megadrive            0777 root root - -
 d    /storage/roms/megadrive-japan      0777 root root - -

--- a/packages/sx05re/libretro/mame/package.mk
+++ b/packages/sx05re/libretro/mame/package.mk
@@ -38,7 +38,8 @@ PKG_MAKE_OPTS_TARGET="REGENIE=1 \
 		      PLATFORM=arm64 \
 		      ARCH= \
 		      TARGET=mame \
-		      SUBTARGET=mame \
+		      SUBTARGET=fmtowns \
+		      SOURCES=fujitsu/fmtowns.cpp,apple/apple2.cpp,apple/apple2e.cpp,apple/apple2gs.cpp \
 		      OSD=retro \
 		      USE_SYSTEM_LIB_EXPAT=1 \
 		      USE_SYSTEM_LIB_ZLIB=1 \


### PR DESCRIPTION
- Change fmtownsux folder to roms
- Mame renamed to fmtowns and only supporting fmtowns and apple2
- Change es_system.cfg to remove mame_libretro from mame section and add new fmtowns mame