### PR TITLE
Generate correct advmame.rc

### DIFF
--- a/packages/sx05re/emulators/advancemame/bin/advmame.sh
+++ b/packages/sx05re/emulators/advancemame/bin/advmame.sh
@@ -23,7 +23,7 @@ if [ ! -L "/storage/.advance" ]; then
     ln -sf ${CONFIG_DIR} /storage/.advance
 fi
 
-if [[ "${1}" = *"roms/arcade"* ]]; then
+if [[ "${1}" = "arcade" ]]; then
 sed -i "s|/roms/mame|/roms/arcade|g" ${CONFIG_DIR}/advmame.rc
  else
 sed -i "s|/roms/arcade|/roms/mame|g" ${CONFIG_DIR}/advmame.rc


### PR DESCRIPTION
If you place your roms in /storage/roms/arcade then this script generated a wrong advmame.rc. Parameter $1 is $PLATFORM and contains only the values "mame" or "arcade", not "roms/mame" or "roms/arcade"