### PR TITLE
Retroarch: Bump to ab6f3ed - 30/05/2024

### DIFF
--- a/packages/sx05re/libretro/retroarch/package.mk
+++ b/packages/sx05re/libretro/retroarch/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="retroarch"
-PKG_VERSION="cfd79a981bc8ebd7d3fea0535f6f2efb36a1d4a3"
+PKG_VERSION="ab6f3edb6abf9d203664ddc5066b5d8cf6980bb0"
 PKG_SITE="https://github.com/libretro/RetroArch"
 PKG_URL="${PKG_SITE}.git"
 PKG_LICENSE="GPLv3"


### PR DESCRIPTION
We need to bump this version to fix bugs.

Also by doing this we can properly test it over time, by the tester group.

Contains fix for Player2 or more for snes/megadrive cores.

Resolves Issues:
https://github.com/EmuELEC/EmuELEC/issues/1343
https://github.com/EmuELEC/EmuELEC/issues/1345

And maybe resolves:
https://github.com/EmuELEC/EmuELEC/issues/1314

Commit details:
https://github.com/libretro/RetroArch/commit/ab6f3edb6abf9d203664ddc5066b5d8cf6980bb0
