### PR TITLE
Going back to an earlier commit

### DIFF
--- a/packages/sx05re/emuelec-ports/bstone/package.mk
+++ b/packages/sx05re/emuelec-ports/bstone/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2021-present Shanti Gilbert (https://github.com/shantigilbert)
 
 PKG_NAME="bstone"
-PKG_VERSION="096da5cea9615eaac896ccfd59891fc55af0ac0e"
+PKG_VERSION="80be4602cd5f765e22dce1909495b3725d5675d3"
 PKG_ARCH="any"
 PKG_SITE="https://github.com/bibendovsky/bstone"
 PKG_URL="${PKG_SITE}.git"

--- a/packages/sx05re/emuelec-ports/bstone/package.mk
+++ b/packages/sx05re/emuelec-ports/bstone/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2021-present Shanti Gilbert (https://github.com/shantigilbert)
 
 PKG_NAME="bstone"
-PKG_VERSION="33db89e84af2d3391025aa79cc79585fadade7b5"
+PKG_VERSION="096da5cea9615eaac896ccfd59891fc55af0ac0e"
 PKG_ARCH="any"
 PKG_SITE="https://github.com/bibendovsky/bstone"
 PKG_URL="${PKG_SITE}.git"


### PR DESCRIPTION
bstone does not compile in latest versions. This is the last version that compiles for now.