### PR TITLE
Update ppsspp.sh

### DIFF
--- a/packages/sx05re/emulators/PPSSPPSDL/scripts/ppsspp.sh
+++ b/packages/sx05re/emulators/PPSSPPSDL/scripts/ppsspp.sh
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2019-present Shanti Gilbert (https://github.com/shantigilbert)
 
+. /etc/profile
+
 AUTOGP=$(get_ee_setting ppsspp_auto_gamepad)
 if [[ "${AUTOGP}" == "1" ]]; then
 	set_ppsspp_joy.sh


### PR DESCRIPTION
get_ee_setting not found because profile file not included.

Noticed the error here:
https://media.discordapp.net/attachments/812795355149369414/1264089398471954493/20240720_021721.jpg?ex=669c9a7e&is=669b48fe&hm=f5c92368004385fd5b50a4083a73fc09b962df8afef4f037b5a321ae86d53ba1&=&format=webp&width=825&height=619
