### PR TITLE
EE - bluetooth fix - custom bt agent to bypass service authorization.

### DIFF
--- a/packages/sx05re/emuelec/bin/batocera/emuelec-bluetooth
+++ b/packages/sx05re/emuelec/bin/batocera/emuelec-bluetooth
@@ -1,4 +1,4 @@
-​#!/usr/bin/python -u
+#!/usr/bin/python -u
 
 ################################################################################
 # SPDX-License-Identifier: GPL-2.0-or-later
@@ -322,12 +322,16 @@ def safe_exit():
     stop_agent()
     sys.exit(0)
 
+def exit_handler(signum, frame):
+    safe_exit()
+
+
 if __name__ == "__main__":
     if len(sys.argv) >= 2:
         SCAN_TIME = int(sys.argv[1])
 
-    signal.signal(signal.SIGINT, safe_exit)
-    signal.signal(signal.SIGTERM, safe_exit)
+    signal.signal(signal.SIGINT, exit_handler)
+    signal.signal(signal.SIGTERM, exit_handler)
 
     print("running scan for " + str(SCAN_TIME) + " seconds.")
     bt = BluetoothCTL()
@@ -370,4 +374,3 @@ if __name__ == "__main__":
             bt.scan_stop()
 
         time.sleep(UPDATE_INTERVAL)
-

--- a/packages/sx05re/emuelec/bin/batocera/emuelec-bluetooth
+++ b/packages/sx05re/emuelec/bin/batocera/emuelec-bluetooth
@@ -149,7 +149,7 @@ class BluetoothCTL:
         ShellIO.execute(["bluetoothctl", "--timeout", str(timeout), "scan", "on"])
 
     def scan_async(self, timeout=10):
-        run_agent
+        run_agent()
         # using stdbuf to flush buffer and get output immediately (bluetoothctl issue)
         cmd = (
             "stdbuf -oL bluetoothctl --timeout " + str(timeout) + " scan on"
@@ -311,7 +311,7 @@ BT_THREAD: Process = None
 # Run agent only when the scan occurs. If it runs when the scan is not occuring it can cause automatic connecting of devices.
 # when they haven't been properly trusted for bluetooth.
 def run_agent():
-        bt_agent = Popen(['emuelec-bluetooth-agent'])
+    bt_agent = Popen(['emuelec-bluetooth-agent'])
 
 def stop_agent():
     # We have to force kill process as it's run method is bugged and does not gracefully terminate.

--- a/packages/sx05re/emuelec/bin/batocera/emuelec-bluetooth
+++ b/packages/sx05re/emuelec/bin/batocera/emuelec-bluetooth
@@ -1,4 +1,4 @@
-#!/usr/bin/python -u
+​#!/usr/bin/python -u
 
 ################################################################################
 # SPDX-License-Identifier: GPL-2.0-or-later
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 import time
 import sys
 import os
+import signal
 from multiprocessing import Process
 
 DEBUG = False
@@ -148,6 +149,7 @@ class BluetoothCTL:
         ShellIO.execute(["bluetoothctl", "--timeout", str(timeout), "scan", "on"])
 
     def scan_async(self, timeout=10):
+        run_agent
         # using stdbuf to flush buffer and get output immediately (bluetoothctl issue)
         cmd = (
             "stdbuf -oL bluetoothctl --timeout " + str(timeout) + " scan on"
@@ -189,6 +191,7 @@ class BluetoothCTL:
 
     def scan_stop(self):
         ShellIO.execute_async(["pkill", "-f", "bluetoothctl"])
+        stop_agent()
 
     @property
     def scanning(self) -> bool:
@@ -305,20 +308,37 @@ UPDATE_INTERVAL = 1
 BEEN_IN_GAME = False
 BT_THREAD: Process = None
 
+# Run agent only when the scan occurs. If it runs when the scan is not occuring it can cause automatic connecting of devices.
+# when they haven't been properly trusted for bluetooth.
+def run_agent():
+        bt_agent = Popen(['emuelec-bluetooth-agent'])
+
+def stop_agent():
+    # We have to force kill process as it's run method is bugged and does not gracefully terminate.
+    ShellIO.execute_async(["pkill", "-9", "-f", "emuelec-bluetooth-agent"])
+
+def safe_exit():
+    ShellIO.execute_async(["pkill", "-f", "bluetoothctl"])
+    stop_agent()
+    sys.exit(0)
+
 if __name__ == "__main__":
     if len(sys.argv) >= 2:
         SCAN_TIME = int(sys.argv[1])
+
+    signal.signal(signal.SIGINT, safe_exit)
+    signal.signal(signal.SIGTERM, safe_exit)
 
     print("running scan for " + str(SCAN_TIME) + " seconds.")
     bt = BluetoothCTL()
 
     if is_bluetooth_running():
         print("bluetooth is already running, exiting.")
-        exit()
+        safe_exit()
 
     if len(bt.controllers) == 0:
         print("no controller found, exiting.")
-        exit()
+        safe_exit()
 
     bt.power = True
     bt.agent = True
@@ -328,11 +348,8 @@ if __name__ == "__main__":
     start_time = time.perf_counter()
     while True:
         diff_time = time.perf_counter() - start_time
-#        if SCAN_TIME >= 0:
-#            if ELAPSED_TIME > SCAN_TIME:
-#        print(diff_time)
         if SCAN_TIME != -1 and diff_time > SCAN_TIME:
-                exit()
+                safe_exit()
 
         if not BEEN_IN_GAME:
             BEEN_IN_GAME = is_in_game()
@@ -353,4 +370,4 @@ if __name__ == "__main__":
             bt.scan_stop()
 
         time.sleep(UPDATE_INTERVAL)
-#        ELAPSED_TIME += UPDATE_INTERVAL
+

--- a/packages/sx05re/emuelec/bin/batocera/emuelec-bluetooth-agent
+++ b/packages/sx05re/emuelec/bin/batocera/emuelec-bluetooth-agent
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+
+import signal
+from bluetool.agent import Client, AgentSvr
+
+
+class MyClient(Client):
+
+    def request_pin_code(self, dev_info):
+        print(dev_info)
+        return raw_input("Input pin code:")
+
+    def request_passkey(self, dev_info):
+        print(dev_info)
+        return raw_input("Input passkey:")
+
+    def request_confirmation(self, dev_info, *args):
+        print(dev_info, args)
+        return raw_input("Input 'yes' to accept request:") == "yes"
+
+    def request_authorization(self, dev_info):
+        print(dev_info)
+        # Here we return true instead of asking for input so request
+        # authorization always returns true.
+        return true
+#        return raw_input("Input 'yes' to accept request:") == "yes"
+
+def handler(signum, frame):
+    svr.shutdown()
+    exit()
+
+svr = AgentSvr(client_class=MyClient)
+
+signal.signal(signal.SIGINT, handler)
+signal.signal(signal.SIGTERM, handler)
+
+svr.run()
+svr.shutdown()


### PR DESCRIPTION
EE - bluetooth fix - custom bt agent to bypass service authorization.

Bypasses service authorization input "yes" to connect devices.
Some controller like the PS dual shock 3 require it, and these code changes fixes it so it should connect ok.

Needs proper testing.

**TO TEST WITHOUT USING A COMPILED BUILD:**
Login to your device with SSH (username: root, password: emuelec ).
Copy and paste the following commands:
```
cd /emuelec/scripts
wget https://raw.githubusercontent.com/EmuELEC/EmuELEC/42ce378d1dad6c71918e09402de646f06ae611b7/packages/sx05re/emuelec/bin/batocera/emuelec-bluetooth
chmod +x /emuelec/scripts/emuelec-bluetooth
wget https://raw.githubusercontent.com/EmuELEC/EmuELEC/ae6c9eb4ac65df59fe2b5549d8ca99a1af6d4871/packages/sx05re/emuelec/bin/batocera/emuelec-bluetooth-agent
chmod +x /emuelec/scripts/emuelec-bluetooth-agent
```
reboot device.

The updated scripts should now use the new method.

See the following instruction to connect your game controller:
https://github.com/EmuELEC/EmuELEC/wiki/Using-PS3-Gamepads

Should fix issue but needs testing:
https://github.com/EmuELEC/EmuELEC/issues/1362

