### PR TITLE
EE - shutdown/reboot profile command overrides for ssh fix

### DIFF
--- a/packages/sx05re/emuelec/profile.d/99-emuelec.conf
+++ b/packages/sx05re/emuelec/profile.d/99-emuelec.conf
@@ -14,6 +14,18 @@ ES_CONF="/storage/.emulationstation/es_settings.cfg"
 EE_DEVICE=$(cat /ee_arch)
 EE_LOG="/emuelec/logs/emuelec.log"
 
+shutdown() {
+	echo "enabling small cores"
+	/usr/bin/emuelec-utils small-cores enable
+	command shutdown $@
+}
+
+reboot() {
+	echo "enabling small cores"
+	/usr/bin/emuelec-utils small-cores enable
+	command reboot $@
+}
+
 get_resolution() {
 # This will return the current video resolution
   echo $( fbset | grep geometry | cut -d$' ' -f2-3 )


### PR DESCRIPTION
EE - shutdown/reboot profile command overrides for ssh fix

About:
When shutting down and rebooting via SSH, enabling small-cores sometimes does not get called, and a hard crash occurs sometimes corrupting the file system. This ensures when issueing shutdown/reboot command from the console that the small cores gets enabled so the system can safely shutdown/reboot.

