### PR TITLE
[EE] Bluetooth Fix - utf8 to latin1 encoding.

### DIFF
--- a/packages/sx05re/emuelec/bin/batocera/emuelec-bluetooth
+++ b/packages/sx05re/emuelec/bin/batocera/emuelec-bluetooth
@@ -44,7 +44,7 @@ class ShellIO:
         if debug:
             print("> " + " ".join(x for x in cmd))
         out: list[str] = []
-        with Popen(cmd, stdout=PIPE, bufsize=1, universal_newlines=True) as p:
+        with Popen(cmd, stdout=PIPE, bufsize=1, universal_newlines=True, encoding="latin-1") as p:
             for line in p.stdout:
                 out.append(line)
                 if debug:
@@ -61,7 +61,7 @@ class ShellIO:
 
     @staticmethod
     def execute_async(cmd: list[str]):
-        Popen(cmd, stdout=PIPE, bufsize=1, universal_newlines=True)
+        Popen(cmd, stdout=PIPE, bufsize=1, universal_newlines=True, encoding="latin-1")
 
 
 class BluetoothCTL:


### PR DESCRIPTION
[EE] Bluetooth Fix - utf8 to latin1 encoding.

Some linux shell commands when executed return characters that exceed utf8's keycode range (0-127). When this occurs originally it causes the emuelec-bluetooth file to generate an error and crash. Latin1 ensures that the command can still be executed, and does not cause the crash when shell commands return characters that are outside of utf-8's character set.

 