### PR TITLE
[Feature] [ES/Retroarch/RetroRun] Rotate Game Screen Option

### DIFF
--- a/packages/sx05re/emuelec-emulationstation/config/es_features.cfg
+++ b/packages/sx05re/emuelec-emulationstation/config/es_features.cfg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <features>
-  <emulator name="libretro" features="ratio, smooth, shaders, pixel_perfect, decoration, latency_reduction, game_translation, nativevideo">
+  <emulator name="libretro" features="ratio, smooth, shaders, pixel_perfect, decoration, latency_reduction, game_translation, nativevideo, rotation">
     <cores>
       <core name="2048" features="netplay, rewind, autosave" />
       <core name="81" features="netplay, rewind, autosave" />
@@ -110,4 +110,5 @@
   <emulator name="FBNEOSA" features="nativevideo" />
 	<emulator name="ports" features="nativevideo, gptokeyb" />
   <emulator name="SCUMMVMSA" features="nativevideo" />
+  <emulator name="retrorun" features="nativevideo, rotation" />
 </features>

--- a/packages/sx05re/emuelec/bin/emuelec-utils
+++ b/packages/sx05re/emuelec/bin/emuelec-utils
@@ -6,6 +6,43 @@
 # Source predefined functions and variables
 . /etc/profile
 
+function set_rotation()
+{
+  local rotate=$1
+  local emulator=$2
+
+  if [[ "${emulator}" == "libretro" ]]; then
+		set_ra_setting "video_rotation" "${rotate}"
+		return		
+  fi
+
+  if [[ "${emulator}" == "retrorun" ]]; then
+		if [[ "${rotate}" == "0" ]]; then
+			set_rr_setting "retrorun_tate_mode" "disabled"
+			set_rr_setting "retrorun_swap_sticks" "false"
+			echo " "
+		else
+			set_rr_setting "retrorun_tate_mode" "enabled"
+			set_rr_setting "retrorun_swap_sticks" "true"
+			echo " -z "
+		fi
+		return
+	fi
+}
+
+function rotation_output() {
+    local emulator=$1
+    local core=$2
+
+    if [[ "${emulator}" == "libretro" ]]; then
+        echo "90 Degrees,180 Degrees,270 Degrees"
+    fi
+
+    if [[ "${emulator}" == "retrorun" ]]; then
+        echo "Tate Mode"
+    fi
+}
+
 function killall_midi()
 {
 	pkill -9 timidity

--- a/packages/sx05re/emuelec/bin/emuelecRunEmu.sh
+++ b/packages/sx05re/emuelec/bin/emuelecRunEmu.sh
@@ -110,6 +110,10 @@ if [[ "${EMULATOR}" = "retrorun" ]]; then
     LIBRETRO=""
 fi
 
+ROTATION_OUTPUT=$(get_ee_setting "${EMULATOR}.rotation_output" "${PLATFORM}" "${BASEROMNAME}")
+[[ -z "${ROTATION_OUTPUT}" ]] && ROTATION_OUTPUT=0
+CMD_ROTATE=$(emuelec-utils set_rotation "${ROTATION_OUTPUT}" "${EMULATOR}")
+
 MIDI_OUTPUT=$(get_ee_setting "ra_midi_output" "${PLATFORM}" "${BASEROMNAME}")
 if [[ ! -z "${MIDI_OUTPUT}" ]]; then
 		emuelec-utils set_midi_source "${MIDI_OUTPUT}" "${EMULATOR}"
@@ -430,15 +434,12 @@ else # Retrorun was selected
         RUNTHIS+="32"
     fi
 
-                if [[ "$EE_DEVICE" == "GameForce" ]]; then
-                        JOY_FILE="/dev/input/by-path/platform-gameforce-gamepad-event-joystick"
-                        if [[ -f "${JOY_FILE}" ]]; then
-                                ln -s /dev/input/event2 ${JOY_FILE}
-                        fi
-                        GPIO_JOYPAD="-g"
-                fi
+		JOY_FILE=$(ls "/dev/input/by-path/*-event-joystick" )
+    if [[ -f "${JOY_FILE}" ]]; then
+            ln -s /dev/input/event2 ${JOY_FILE}
+    fi
 
-    RUNTHIS+=' --triggers -n ${GPIO_JOYPAD} -d /storage/roms/bios /tmp/cores/${EMU}.so "${ROMNAME}"'
+    RUNTHIS+=' ${CMD_ROTATE} --triggers -g -d /storage/roms/bios /tmp/cores/${EMU}.so "${ROMNAME}"'
 
 fi # end Libretro/retrorun or standalone emu logic
 
@@ -487,6 +488,8 @@ fi
         reset > /dev/console < /dev/null 2>&1
 
 emuelec-utils end_app_video
+
+emuelec-utils set_rotation "0" "${EMULATOR}"
 
 # Kill MIDI Processes
 emuelec-utils set_midi_source "None" "${EMULATOR}"

--- a/projects/Rockchip/devices/GameForce/patches/lib32-retrorun/flycast_gameforce_chi_rotation_fix.patch
+++ b/projects/Rockchip/devices/GameForce/patches/lib32-retrorun/flycast_gameforce_chi_rotation_fix.patch
@@ -1,22 +1,13 @@
 diff --git a/src/video.cpp b/src/video.cpp
-index 6c095c6..dff03ee 100755
+index d168eda..66238ee 100755
 --- a/src/video.cpp
 +++ b/src/video.cpp
-@@ -941,7 +941,7 @@ inline void prepareScreen(int width, int height)
-         y = 0;
-         h = go2_display_height_get(display);
-         w = go2_display_width_get(display);
--        isTate = (Retrorun_Core == RETRORUN_CORE_FLYCAST); // we rotate the screen (Tate) for some arcade games when apsect ratio < 0
-+        isTate = false; //(Retrorun_Core == RETRORUN_CORE_FLYCAST); // we rotate the screen (Tate) for some arcade games when apsect ratio < 0
-     }
- }
- int colorInc = 0;
-@@ -1565,7 +1565,7 @@ void core_video_refresh(const void *data, unsigned width, unsigned height, size_
- 
+@@ -763,7 +764,7 @@ void core_video_refresh(const void *data, unsigned width, unsigned height, size_
+
          real_aspect_ratio = aspect_ratio;
          _351BlitRotation = isTate ? GO2_ROTATION_DEGREES_270 : GO2_ROTATION_DEGREES_0;
 -        _351Rotation = isTate ? GO2_ROTATION_DEGREES_180 : GO2_ROTATION_DEGREES_270;
-+        _351Rotation = isTate ? GO2_ROTATION_DEGREES_180 : GO2_ROTATION_DEGREES_0;
++        _351Rotation = isTate ? GO2_ROTATION_DEGREES_270 : GO2_ROTATION_DEGREES_0; // test
          first_video_refresh = false;
      }
      if (height != currentHeight || width != currentWidth)

--- a/projects/Rockchip/devices/GameForce/patches/retrorun/flycast_gameforce_chi_rotation_fix.patch
+++ b/projects/Rockchip/devices/GameForce/patches/retrorun/flycast_gameforce_chi_rotation_fix.patch
@@ -1,22 +1,13 @@
 diff --git a/src/video.cpp b/src/video.cpp
-index d168eda..67ad27d 100755
+index d168eda..66238ee 100755
 --- a/src/video.cpp
 +++ b/src/video.cpp
-@@ -641,7 +641,7 @@ void prepareScreen(int width, int height)
-         y = 0;
-         h = go2_display_height_get(display);
-         w = go2_display_width_get(display);
--        isTate = (Retrorun_Core == RETRORUN_CORE_FLYCAST); // we rotate the screen (Tate) for some arcade games when apsect ratio < 0
-+        isTate = false; //(Retrorun_Core == RETRORUN_CORE_FLYCAST); // we rotate the screen (Tate) for some arcade games when apsect ratio < 0
-     }
- }
- 
-@@ -763,7 +763,7 @@ void core_video_refresh(const void *data, unsigned width, unsigned height, size_
- 
+@@ -763,7 +764,7 @@ void core_video_refresh(const void *data, unsigned width, unsigned height, size_
+
          real_aspect_ratio = aspect_ratio;
          _351BlitRotation = isTate ? GO2_ROTATION_DEGREES_270 : GO2_ROTATION_DEGREES_0;
 -        _351Rotation = isTate ? GO2_ROTATION_DEGREES_180 : GO2_ROTATION_DEGREES_270;
-+        _351Rotation = isTate ? GO2_ROTATION_DEGREES_180 : GO2_ROTATION_DEGREES_0;
++        _351Rotation = isTate ? GO2_ROTATION_DEGREES_270 : GO2_ROTATION_DEGREES_0; // test
          first_video_refresh = false;
      }
      if (height != currentHeight || width != currentWidth)

--- a/projects/Rockchip/packages/retrorun/patches/001-tatemode.patch
+++ b/projects/Rockchip/packages/retrorun/patches/001-tatemode.patch
@@ -1,0 +1,79 @@
+diff --git a/retrorun b/retrorun
+index 5491dd6..a5a26ec 100755
+Binary files a/retrorun and b/retrorun differ
+diff --git a/src/globals.cpp b/src/globals.cpp
+index ff0621b..bc72f01 100755
+--- a/src/globals.cpp
++++ b/src/globals.cpp
+@@ -7,6 +7,7 @@ RETRORUN_CORE_TYPE Retrorun_Core = RETRORUN_CORE_UNKNOWN;
+ Device device = UNKNOWN;
+ bool force_left_analog_stick = true;
+
++bool opt_is_tate = false;
+ bool opt_triggers = false;
+ bool gpio_joypad = false;
+ float opt_aspect = 0.0f;
+diff --git a/src/globals.h b/src/globals.h
+index 23f3bc0..4cbf6de 100755
+--- a/src/globals.h
++++ b/src/globals.h
+@@ -47,6 +47,7 @@ extern bool force_left_analog_stick;
+
+ extern float fps;
+ extern bool opt_triggers;
++extern bool opt_is_tate;
+ extern bool gpio_joypad;
+ extern float opt_aspect;
+ extern float aspect_ratio;
+diff --git a/src/main.cpp b/src/main.cpp
+index 0cbbfe2..2d7a799 100644
+--- a/src/main.cpp
++++ b/src/main.cpp
+@@ -98,6 +98,7 @@ struct option longopts[] = {
+     {"triggers", no_argument, NULL, 't'},
+     {"analog", no_argument, NULL, 'n'},
+     {"fps", no_argument, NULL, 'f'},
++		{"tatemode", no_argument, NULL, 'z'},
+     {0, 0, 0, 0}};
+
+ static struct
+@@ -883,7 +884,7 @@ int main(int argc, char *argv[])
+     int c;
+     int option_index = 0;
+
+-    while ((c = getopt_long(argc, argv, "s:d:a:b:v:grtnfc:", longopts, &option_index)) != -1)
++    while ((c = getopt_long(argc, argv, "s:d:a:b:v:grtnfcz:", longopts, &option_index)) != -1)
+     {
+         switch (c)
+         {
+@@ -929,7 +930,9 @@ int main(int argc, char *argv[])
+         case 'c':
+             opt_setting_file = optarg;
+             break;
+-
++				case 'z':
++						opt_is_tate = true;
++						break;
+         default:
+             printf("Unknown option. '%s'\n", longopts[option_index].name);
+             exit(EXIT_FAILURE);
+diff --git a/src/video.cpp b/src/video.cpp
+index d168eda..66238ee 100755
+--- a/src/video.cpp
++++ b/src/video.cpp
+@@ -577,6 +577,7 @@ bool cmpf(float A, float B, float epsilon = 0.005f)
+ void prepareScreen(int width, int height)
+ {
+     screen_aspect_ratio = (float)go2_display_height_get(display) / (float)go2_display_width_get(display);
++		isTate = opt_is_tate;
+     if (aspect_ratio >= 1.0f)
+     {
+         if (isWideScreen)
+@@ -641,7 +642,7 @@ void prepareScreen(int width, int height)
+         y = 0;
+         h = go2_display_height_get(display);
+         w = go2_display_width_get(display);
+-        isTate = (Retrorun_Core == RETRORUN_CORE_FLYCAST); // we rotate the screen (Tate) for some arcade games when apsect ratio < 0
++        // isTate = (Retrorun_Core == RETRORUN_CORE_FLYCAST); // we rotate the screen (Tate) for some arcade games when apsect ratio < 0
+     }
+ }


### PR DESCRIPTION
[Feature] [ES/Retroarch] Rotate Game Screen Option

Feature Request:
https://github.com/EmuELEC/EmuELEC/issues/1387

Depends on:
https://github.com/EmuELEC/emuelec-emulationstation/pull/101
https://github.com/EmuELEC/emuelec-emulationstation/pull/103

Steps for Testing changes on GameForce.

1. Apply PR to your build.
2. You need to update Emulation package file on your downloaded code. Find this file and line:
https://github.com/EmuELEC/EmuELEC/blob/ca85b645501bf31c8fe598a02f7379250870f865/packages/sx05re/emuelec-emulationstation/package.mk#L5
Change it too:
```
PKG_VERSION="3065ed6a8f642ffe1aa0d1e8fbf107201aa5442a"
```
3. Build it.
4. Get in a gamelist that allows Retrorun Emulator. (Press select get into Advanced Game Settings, Change Emulator to retrorun).
5. Enable or Disable Screen Rotation "Tate Mode" option towards the bottom.
6. Check when Disable screen should be normal. When Enable should display Vertically, and controls should work now on right side of device.