### PR TITLE
[EE] ES Menu Option - No Logging Support 2.

### DIFF
--- a/packages/sx05re/emuelec/bin/emuelecRunEmu.sh
+++ b/packages/sx05re/emuelec/bin/emuelecRunEmu.sh
@@ -70,6 +70,9 @@ else
     set_ra_setting "log_verbosity" true
     set_retroarch_logs 1 2
     if [[ "${LOGLEVEL}" == "debug" ]]; then
+        set_retroarch_logs 0 0
+    fi
+    if [[ "${LOGLEVEL}" == "info" ]]; then
         set_retroarch_logs 1 1
     fi
     if [[ "${LOGLEVEL}" == "warning" ]]; then


### PR DESCRIPTION
[EE] ES Menu Option - No Logging Support 2.

Currently the ES Menu option does not have a no logging option. When in ES the minimal option is selected it should not log anything.

This relies on latest Dev branch.

copy this emuelecRunEmu /emuelec/bin and give it exec permissions rather than creating a new image.

Issue Here:
https://github.com/EmuELEC/EmuELEC/issues/1389