### PR TITLE
Enable is31fl32xx LED driver as loadable module

### DIFF
--- a/projects/Amlogic-ce/devices/Amlogic-ng/linux/linux.aarch64.conf
+++ b/projects/Amlogic-ce/devices/Amlogic-ng/linux/linux.aarch64.conf
@@ -4888,7 +4888,7 @@ CONFIG_LEDS_PWM=y
 # CONFIG_LEDS_TLC591XX is not set
 # CONFIG_LEDS_LM355x is not set
 # CONFIG_LEDS_IS31FL319X is not set
-# CONFIG_LEDS_IS31FL32XX is not set
+CONFIG_LEDS_IS31FL32XX=m
 
 #
 # LED driver for blink(1) USB RGB LED is under Special HID drivers (HID_THINGM)


### PR DESCRIPTION
Can this LED driver be enabled as a loadable module (16k) for the FireTV 2nd gen Cube?