### PR TITLE
EE - input - joypads - remove duplicate cfg records

### DIFF
--- a/packages/sx05re/emuelec-emulationstation/config/scripts/configscripts/retroarch.sh
+++ b/packages/sx05re/emuelec-emulationstation/config/scripts/configscripts/retroarch.sh
@@ -384,6 +384,11 @@ function onend_retroarch_joystick() {
         mv "${file}" "${file}.bak" > /dev/null 2>&1
     done < <(grep -Fl "\"${DEVICE_NAME}\"" "${dir}/"*.cfg 2>/dev/null)
 
+		for file in /tmp/joypads/*.*; do
+			txt=$( cat "$file" | grep -E -c "^input_vendor_id = \"${input_vendor}\"$|^input_product_id = \"${input_product}\"$" )
+			[[ "${txt}" == "2" ]] && mv "${file}" "${file}.bak" > /dev/null 2>&1
+		done
+
     # sanitise filename
     file="${DEVICE_NAME//[\?\<\>\\\/:\*\|]/}.cfg"
 


### PR DESCRIPTION
EE - input - joypads - remove duplicate cfg records

Currently the retroarch remapping script only moves the configs that have duplicate names. However, this is unreliable because SDL uses different names to the udev records, which can result in alternate configs being loaded into retroarch. This patch makes it so when remapping all configs that have the same product and vendor id removed, so retroarch will only load the record that was remapped.

Should resolve:
https://github.com/EmuELEC/EmuELEC/issues/1414
