### PR TITLE
Emuelec Retro Achievements 4.8

### DIFF
--- a/packages/sx05re/emulators/PPSSPPSDL/scripts/ppsspp.sh
+++ b/packages/sx05re/emulators/PPSSPPSDL/scripts/ppsspp.sh
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2019-present Shanti Gilbert (https://github.com/shantigilbert)
 
+. /etc/profile
+
 AUTOGP=$(get_ee_setting ppsspp_auto_gamepad)
 if [[ "${AUTOGP}" == "1" ]]; then
 	set_ppsspp_joy.sh

--- a/packages/sx05re/emulators/PPSSPPSDL/scripts/ppsspp.sh
+++ b/packages/sx05re/emulators/PPSSPPSDL/scripts/ppsspp.sh
@@ -3,12 +3,12 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2019-present Shanti Gilbert (https://github.com/shantigilbert)
 
-. /etc/profile
-
 AUTOGP=$(get_ee_setting ppsspp_auto_gamepad)
 if [[ "${AUTOGP}" == "1" ]]; then
 	set_ppsspp_joy.sh
 fi
+
+ppssppcheevos.sh
 
 ARG=${1//[\\]/}
 export SDL_AUDIODRIVER=alsa          

--- a/packages/sx05re/emulators/PPSSPPSDL/scripts/ppssppcheevos.sh
+++ b/packages/sx05re/emulators/PPSSPPSDL/scripts/ppssppcheevos.sh
@@ -1,0 +1,40 @@
+#! /bin/bash
+
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2022-present Hector Calvarro (https://github.com/kelvfimer)
+#Script for setting up cheevos on duckstation emuelec. it extracts the data from emuelec.conf and it constructs the entries in seetings.ini if [Cheevos] or Enabled = True or Enable = False are not presented
+
+# Source predefined functions and variables
+. /etc/profile
+
+PPSSPP_ACHIEVEMENTS="/storage/.config/ppsspp/PSP/SYSTEM/ppsspp_retroachievements.dat"
+PPSSPP_INI="/storage/.config/ppsspp/PSP/SYSTEM/ppsspp.ini"
+
+#Extract username and password from emuelec.conf
+username=$(get_ee_setting "global.retroachievements.username")
+password=$(get_ee_setting "global.retroachievements.password")
+token=$(grep "cheevos_token" /storage/.config/retroarch/retroarch.cfg | cut -d'"' -f2)
+
+#Test the token if empty exit 1.
+if [ -z "${token}" ]
+then
+      echo "Token is empty you must log in retroachievement first in retroarch achievements"
+      exit 1
+fi
+echo "${token}" > ${PPSSPP_ACHIEVEMENTS}
+
+#Variables for checking if [Cheevos] or enabled true or false are presente.
+zcheevos=$(grep -Fx "[Achievements]" ${PPSSPP_INI})
+datets=$(date +%s%N | cut -b1-13)
+
+if ([ -z "${zcheevos}" ])
+then
+    echo -e "[Achievements]\nAchievementsEnable = True\nAchievementsUserName = ${username}\n" >> ${PPSSPP_INI}
+else
+    # Verificar y actualizar AchievementsUserName si es necesario
+    if ! grep -q "^AchievementsUserName = " ${PPSSPP_INI}; then
+        sed -i "/^\[Achievements\]/a AchievementsUserName = ${username}" ${PPSSPP_INI}
+    else
+        sed -i "/^\[Achievements\]/,/^\[/{s/^AchievementsUserName = .*/AchievementsUserName = ${username}/;}" ${PPSSPP_INI}
+    fi
+fi

--- a/packages/sx05re/emulators/duckstation/scripts/duckstation.sh
+++ b/packages/sx05re/emulators/duckstation/scripts/duckstation.sh
@@ -31,13 +31,8 @@ if [[ "${AUTOGP}" == "1" ]]; then
 	set_duckstation_joy.sh
 fi
 
-#Setting Cheevos if enabled on emulationstation. First check if token entry is not present
-ztoken=$(grep "Token =" /storage/.config/emuelec/configs/duckstation/settings.ini)
+duckstationcheevos.sh
 
-if ([ -z "${ztoken}" ]) 
-then
-    duckstationcheevos.sh
-fi
 
 if [[ "${1}" == *"duckstation_gui.pbp"* ]]; then
     duckstation-nogui -fullscreen

--- a/packages/sx05re/emulators/flycastsa/scripts/flycast.sh
+++ b/packages/sx05re/emulators/flycastsa/scripts/flycast.sh
@@ -20,4 +20,6 @@ if [[ "${AUTOGP}" != "0" ]]; then
   set_flycast_joy.sh
 fi
 
+flycastcheevos.sh
+
 flycast "${1}"

--- a/packages/sx05re/emulators/flycastsa/scripts/flycastcheevos.sh
+++ b/packages/sx05re/emulators/flycastsa/scripts/flycastcheevos.sh
@@ -1,0 +1,41 @@
+#! /bin/bash
+
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2022-present Hector Calvarro (https://github.com/kelvfimer)
+# Script for setting up cheevos on duckstation emuelec. it extracts the data from emuelec.conf and it constructs the entries in settings.ini if [Cheevos] or Enabled = True or Enable = False are not presented
+
+. /etc/profile
+
+FLYCAST_CFG="/storage/.config/flycast/emu.cfg"
+
+# Extract username and password from emuelec.conf
+username=$(get_ee_setting "global.retroachievements.username")
+password=$(get_ee_setting "global.retroachievements.password")
+token=$(grep "cheevos_token" /storage/.config/retroarch/retroarch.cfg | cut -d'"' -f2)
+
+# Test the token if empty exit 1.
+if [ -z "${token}" ]; then
+    echo "Token is empty you must log in retroachievement first in retroarch achievements"
+    exit 1
+fi
+
+# Variables for checking if [Cheevos] or enabled true or false are present.
+zcheevos=$(grep -Fx "[achievements]" ${FLYCAST_CFG})
+
+if [ -z "${zcheevos}" ]; then
+    # Añadir la sección [achievements] con los valores
+    sed -i "\$a [achievements]\nEnabled = yes\nUserName = ${username}\nToken = ${token}" ${FLYCAST_CFG}
+else
+    # Verificar y actualizar UserName y Token si es necesario
+    if ! grep -q "^UserName = " ${FLYCAST_CFG}; then
+        sed -i "/^\[achievements\]/a UserName = ${username}" ${FLYCAST_CFG}
+    else
+        sed -i "/^\[achievements\]/,/^\[/{s/^UserName = .*/UserName = ${username}/;}" ${FLYCAST_CFG}
+    fi
+
+    if ! grep -q "^Token = " ${FLYCAST_CFG}; then
+        sed -i "/^\[achievements\]/a Token = ${token}" ${FLYCAST_CFG}
+    else
+        sed -i "/^\[achievements\]/,/^\[/{s/^Token = .*/Token = ${token}/;}" ${FLYCAST_CFG}
+    fi
+fi


### PR DESCRIPTION
This pull request includes several changes to the emulator scripts to improve the setup and configuration of RetroAchievements (Cheevos). The changes mainly focus on adding new scripts for setting up achievements and modifying existing scripts to call these new scripts.

### Additions and Improvements to Cheevos Setup:

* **New Script for PPSSPP Cheevos**:
  - Added `ppssppcheevos.sh` to set up achievements for PPSSPP by extracting data from `emuelec.conf` and constructing entries in `ppsspp.ini`. (`packages/sx05re/emulators/PPSSPPSDL/scripts/ppssppcheevos.sh`)

* **New Script for Flycast Cheevos**:
  - Added `flycastcheevos.sh` to set up achievements for Flycast by extracting data from `emuelec.conf` and constructing entries in `emu.cfg`. (`packages/sx05re/emulators/flycastsa/scripts/flycastcheevos.sh`)

### Modifications to Existing Scripts:

* **PPSSPP Script Update**:
  - Modified `ppsspp.sh` to call the new `ppssppcheevos.sh` script. (`packages/sx05re/emulators/PPSSPPSDL/scripts/ppsspp.sh`)

* **DuckStation Script Update**:
  - Updated `duckstation.sh` to call `duckstationcheevos.sh` unconditionally, removing the previous conditional check for the token. (`packages/sx05re/emulators/duckstation/scripts/duckstation.sh`)

* **Flycast Script Update**:
  - Modified `flycast.sh` to call the new `flycastcheevos.sh` script. (`packages/sx05re/emulators/flycastsa/scripts/flycast.sh`)

### Refactoring and Code Cleanup:

* **DuckStation Cheevos Script Refactor**:
  - Refactored `duckstationcheevos.sh` to use `get_ee_setting` for extracting username and password, and to streamline the logic for updating `settings.ini`. (`packages/sx05re/emulators/duckstation/scripts/duckstationcheevos.sh`) [[1]](diffhunk://#diff-048f0347d2da8accb71fb5f88fb03785664083abffd0a5876e8bfdef55d7b820R7-R14) [[2]](diffhunk://#diff-048f0347d2da8accb71fb5f88fb03785664083abffd0a5876e8bfdef55d7b820L22-R50)