### PR TITLE
dev - setres framebuffer configuration fixes 2

### DIFF
--- a/packages/sx05re/emuelec/bin/emuelec-utils
+++ b/packages/sx05re/emuelec/bin/emuelec-utils
@@ -463,8 +463,8 @@ function init_app_video() {
 
 	echo "$(cat /sys/class/display/mode)" > /tmp/EE_LASTVIDEO
 	local VIDEO_EMU=$(get_ee_setting nativevideo "${PLATFORM}" "${BASEROMNAME}")
-	[[ -z "$VIDEO_EMU" ]] && VIDEO_EMU=$LAST_VIDEO
-	
+	[[ -z "$VIDEO_EMU" ]] && VIDEO_EMU=$(cat /tmp/EE_LASTVIDEO)
+
 	# Show splash screen if enabled
 	local SPL=$(get_ee_setting ee_splash.enabled)
 	[ "${SPL}" -eq "1" ] && ${TBASH} show_splash.sh gameloading "${PLATFORM}" "${ROMNAME}"

--- a/packages/sx05re/emuelec/bin/emustation-config
+++ b/packages/sx05re/emuelec/bin/emustation-config
@@ -295,4 +295,10 @@ if [[ ! -f "$REMAP_VERSION" ]]; then
 	echo "2" > "${REMAP_VERSION}"
 fi
 
+FRAMEBUFFER_VERSION="/emuelec/configs/FRAMEBUFFER_VERSION"
+if [[ ! -f "$FRAMEBUFFER_VERSION" ]]; then
+	grep -Ev "^.*\framebuffer.*=.*$" /emuelec/configs/emuelec.conf > /tmp/emuelec.conf.bak && mv /tmp/emuelec.conf.bak /emuelec/configs/emuelec.conf
+	echo "2" > "${FRAMEBUFFER_VERSION}"
+fi
+
 exit 0

--- a/packages/sx05re/emuelec/bin/setres.sh
+++ b/packages/sx05re/emuelec/bin/setres.sh
@@ -172,7 +172,7 @@ if [[ "${MODE}" == *"cvbs" ]]; then
   fi
 fi
 
-CUSTOM_RES=$(get_ee_setting ${ES_MODE}framebuffer.${MODE} "${PLATFORM}" "${ROMNAME}")
+CUSTOM_RES=$(get_ee_setting ${ES_MODE}framebuffer "${PLATFORM}" "${ROMNAME}")
 #[[ -z "${CUSTOM_RES}" ]] && CUSTOM_RES=$(get_ee_setting ee_framebuffer.${MODE})
 if [[ ! -z "${CUSTOM_RES}" ]]; then
   declare -a RES=($(echo "${CUSTOM_RES}"))
@@ -220,10 +220,12 @@ if [[ -f "/storage/.config/${MODE}_offsets" ]]; then
   CUSTOM_OFFSETS=( $( cat "/storage/.config/${MODE}_offsets" ) )
 fi
 
-OFFSET_SETTING=$(get_ee_setting ${ES_MODE}framebuffer_border.${MODE} "${PLATFORM}" "${ROMNAME}")
+OFFSET_SETTING=$(get_ee_setting ${ES_MODE}framebuffer_border "${PLATFORM}" "${ROMNAME}")
 #[[ -z "${OFFSET_SETTING}" ]] && OFFSET_SETTING="$(get_ee_setting ${MODE}.ee_offsets)"
 if [[ ! -z "${OFFSET_SETTING}" ]]; then
   CUSTOM_OFFSETS=( ${OFFSET_SETTING} )
+	CUSTOM_OFFSETS[2]=$(( ${PSW} - CUSTOM_OFFSETS[2] - 1 ))
+	CUSTOM_OFFSETS[3]=$(( ${PSH} - CUSTOM_OFFSETS[3] - 1 ))
 fi
 
 # Now that the primary buffer has been acquired we blank it again because the new

--- a/packages/sx05re/emulators/advancemame/bin/set_advmame_joy.sh
+++ b/packages/sx05re/emulators/advancemame/bin/set_advmame_joy.sh
@@ -108,14 +108,13 @@ set_pad(){
   echo "GC_CONFIG=${GC_CONFIG}"
   [[ -z ${GC_CONFIG} ]] && return
 
-  [[ -z "${JOY_NAME}" ]] && JOY_NAME=$(echo ${GC_CONFIG} | cut -d',' -f2)
+  JOY_NAME="$(cat "/tmp/JOYPAD_NAMES/JOYPAD${1}.txt" | cut -d'"' -f2 )"
   [[ -z "${JOY_NAME}" ]] && return
 
-  local GAMEPAD="$(cat "/tmp/JOYPAD_NAMES/JOYPAD${1}.txt" | sed "s|,||g" | sed "s|_||g" | cut -d'"' -f 2 \
-    | sed "s|(||" | sed "s|)||" | sed -e 's/[^A-Za-z0-9._-]/ /g' | sed 's/[[:blank:]]*$//' \
-    | sed 's/-//' | sed -e 's/[^A-Za-z0-9._-]/_/g' |tr '[:upper:]' '[:lower:]' | tr -d '.')"
+  local GAMEPAD="$(advj | grep "'${JOY_NAME}'" | cut -d"'" -f2 | head -n 1 )"
+  [[ -z "${GAMEPAD}" ]] && return
 
-  BTN_H0=$(advj | grep -B 1 -E "^joy [0-9] '${GAMEPAD}' .*" | grep sticks: | sed "s|sticks:\ ||" | tr -d ' ')
+  BTN_H0=$(advj | grep -B 1 -E "^joy ${P_INDEX}.*" | grep sticks: | sed "s|sticks:\ ||" | tr -d ' ')
   ADVMAME_VALUES["h0.1"]="stick${BTN_H0},y,up"
   ADVMAME_VALUES["h0.4"]="stick${BTN_H0},y,down"
   ADVMAME_VALUES["h0.8"]="stick${BTN_H0},x,left"


### PR DESCRIPTION
dev - setres framebuffer configuration fixes 2

For Testers with this PR see:
https://github.com/Langerz82/EmuELEC/releases/tag/v4.8TEST20241106123254

Currently framebuffer config settings are tied into the video mode. This causes issues when the native video is changed and has become too complex to code for. These changes along with the dependent PR simplify the ability to set the frambuffer different from the resolution and to apply border values for fine tuning adjustment for analog displays.

NOTE - framebuffer dimensions setting is no longer tied to the display resolution, that means if you change the framebuffer resolution for all emu's (in emuelec settings >> danger zone) it will always change the frambuffer to it setting regardless of the resolution you have in-game even when it's set to auto or you have set the native video differently. If you don't want the frame buffer to set differently keep it at auto.
Border changes should work fine, however they are no longer tied to resolution either. So if you say run native video 640x480 (640x480p60hz) and set a border value, If you change the native video to a new resolution say 1024x768 the border will apply to that resolution as well. To remove bordering you need to set the values, to top left right bottom all 0.

Depends on:
https://github.com/EmuELEC/emuelec-emulationstation/pull/106