### PR TITLE
dev - setres framebuffer configuration fixes 4

### DIFF
--- a/packages/sx05re/emuelec/bin/emuelec-utils
+++ b/packages/sx05re/emuelec/bin/emuelec-utils
@@ -463,8 +463,8 @@ function init_app_video() {
 
 	echo "$(cat /sys/class/display/mode)" > /tmp/EE_LASTVIDEO
 	local VIDEO_EMU=$(get_ee_setting nativevideo "${PLATFORM}" "${BASEROMNAME}")
-	[[ -z "$VIDEO_EMU" ]] && VIDEO_EMU=$LAST_VIDEO
-	
+	[[ -z "$VIDEO_EMU" ]] && VIDEO_EMU=$(cat /tmp/EE_LASTVIDEO)
+
 	# Show splash screen if enabled
 	local SPL=$(get_ee_setting ee_splash.enabled)
 	[ "${SPL}" -eq "1" ] && ${TBASH} show_splash.sh gameloading "${PLATFORM}" "${ROMNAME}"

--- a/packages/sx05re/emuelec/bin/emustation-config
+++ b/packages/sx05re/emuelec/bin/emustation-config
@@ -289,11 +289,19 @@ emuelec-utils setauddev
 # Checks and sets the resolution for starting ES.
 check_res.sh
 
+# START - SECTIONS TO WIPE PREVIOUS VERSION CONFIG DATA
 REMAP_VERSION="/emuelec/configs/JOY_REMAP_VERSION"
 if [[ ! -f "$REMAP_VERSION" ]]; then
 	grep -Ev "^.*\.joy_btn.*=.*$" /emuelec/configs/emuelec.conf > /tmp/emuelec.conf.bak && mv /tmp/emuelec.conf.bak /emuelec/configs/emuelec.conf
 	echo "2" > "${REMAP_VERSION}"
 fi
+
+FRAMEBUFFER_VERSION="/emuelec/configs/FRAMEBUFFER_VERSION"
+if [[ ! -f "$FRAMEBUFFER_VERSION" ]]; then
+	grep -Ev "^.*\framebuffer.*=.*$" /emuelec/configs/emuelec.conf > /tmp/emuelec.conf.bak && mv /tmp/emuelec.conf.bak /emuelec/configs/emuelec.conf
+	echo "2" > "${FRAMEBUFFER_VERSION}"
+fi
+# END - SECTIONS TO WIPE PREVIOUS VERSION CONFIG DATA
 
 RA_CORE_OPTION="/storage/.config/retroarch/retroarch-core-options.cfg"
 HAS_RA_CORE_OPTION_X68K_FDD_FIX=$(cat "${RA_CORE_OPTION}" | grep px68k_save_fdd_path)

--- a/packages/sx05re/emuelec/bin/setres.sh
+++ b/packages/sx05re/emuelec/bin/setres.sh
@@ -51,7 +51,7 @@ get_resolution_size()
 
   case ${MODE} in
     480cvbs)
-      PSW=640
+      PSW=720
       PSH=480
       [[ -z "${FBW}" ]] && FBW=1024
       [[ -z "${FBH}" ]] && FBH=768
@@ -172,7 +172,7 @@ if [[ "${MODE}" == *"cvbs" ]]; then
   fi
 fi
 
-CUSTOM_RES=$(get_ee_setting ${ES_MODE}framebuffer.${MODE} "${PLATFORM}" "${ROMNAME}")
+CUSTOM_RES=$(get_ee_setting ${ES_MODE}framebuffer "${PLATFORM}" "${ROMNAME}")
 #[[ -z "${CUSTOM_RES}" ]] && CUSTOM_RES=$(get_ee_setting ee_framebuffer.${MODE})
 if [[ ! -z "${CUSTOM_RES}" ]]; then
   declare -a RES=($(echo "${CUSTOM_RES}"))
@@ -220,10 +220,12 @@ if [[ -f "/storage/.config/${MODE}_offsets" ]]; then
   CUSTOM_OFFSETS=( $( cat "/storage/.config/${MODE}_offsets" ) )
 fi
 
-OFFSET_SETTING=$(get_ee_setting ${ES_MODE}framebuffer_border.${MODE} "${PLATFORM}" "${ROMNAME}")
+OFFSET_SETTING=$(get_ee_setting ${ES_MODE}framebuffer_border "${PLATFORM}" "${ROMNAME}")
 #[[ -z "${OFFSET_SETTING}" ]] && OFFSET_SETTING="$(get_ee_setting ${MODE}.ee_offsets)"
 if [[ ! -z "${OFFSET_SETTING}" ]]; then
   CUSTOM_OFFSETS=( ${OFFSET_SETTING} )
+	CUSTOM_OFFSETS[2]=$(( ${PSW} - CUSTOM_OFFSETS[2] - 1 ))
+	CUSTOM_OFFSETS[3]=$(( ${PSH} - CUSTOM_OFFSETS[3] - 1 ))
 fi
 
 # Now that the primary buffer has been acquired we blank it again because the new


### PR DESCRIPTION
dev - setres framebuffer configuration fixes 4

For Testers with this PR see:
https://github.com/Langerz82/EmuELEC/releases/tag/v4.8TEST20241106123254

Currently framebuffer config settings are tied into the video mode. This causes issues when the native video is changed and has become too complex to code for. These changes along with the dependent PR simplify the ability to set the frambuffer different from the resolution and to apply border values for fine tuning adjustment for analog displays.

NOTE - framebuffer dimensions setting is no longer tied to the display resolution, that means if you change the framebuffer resolution for all emu's (in emuelec settings >> danger zone) it will always change the frambuffer to it setting regardless of the resolution you have in-game even when it's set to auto or you have set the native video differently. If you don't want the frame buffer to set differently keep it at auto.
Border changes should work fine, however they are no longer tied to resolution either. So if you say run native video 640x480 (640x480p60hz) and set a border value, If you change the native video to a new resolution say 1024x768 the border will apply to that resolution as well. To remove bordering you need to set the values, to top left right bottom all 0.

Depends on:
https://github.com/EmuELEC/emuelec-emulationstation/pull/106