### PR TITLE
Update Crystal theme to add ikemen and update language files

### DIFF
--- a/packages/sx05re/emuelec-emulationstation/themes/Crystal/package.mk
+++ b/packages/sx05re/emuelec-emulationstation/themes/Crystal/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2020-present Shanti Gilbert (https://github.com/shantigilbert)
 
 PKG_NAME="Crystal"
-PKG_VERSION="4b88c7b143bd530a8039b226676f47734466c229"
+PKG_VERSION="fb379817f72ceb06cd329ab05c239bf85b40b0c1"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
This pull request includes a small update to the `packages/sx05re/emuelec-emulationstation/themes/Crystal/package.mk` file. The change updates the `PKG_VERSION` to a new commit hash.

* [`packages/sx05re/emuelec-emulationstation/themes/Crystal/package.mk`](diffhunk://#diff-7e09c081ffb930800cd030249efdea109ff23f7db7aa3fe38cb0a758144a2a24L5-R5): Updated `PKG_VERSION` to `fb379817f72ceb06cd329ab05c239bf85b40b0c1`.