### PR TITLE
update kernel-firmware 20240811

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Based on  [CoreELEC](https://github.com/CoreELEC/CoreELEC) and [Lakka](https://g
 These instructions are only for Debian/Ubuntu based systems.
 
 ```
-$ apt install gcc make git unzip wget xz-utils libsdl2-dev libsdl2-mixer-dev libfreeimage-dev libfreetype6-dev libcurl4-openssl-dev rapidjson-dev libasound2-dev libgl1-mesa-dev build-essential libboost-all-dev cmake fonts-droid-fallback libvlc-dev libvlccore-dev vlc-bin texinfo premake4 golang libssl-dev curl patchelf xmlstarlet default-jre xsltproc libvpx-dev
+$ apt install gcc make git unzip wget xz-utils libsdl2-dev libsdl2-mixer-dev libfreeimage-dev libfreetype6-dev libcurl4-openssl-dev rapidjson-dev libasound2-dev libgl1-mesa-dev build-essential libboost-all-dev cmake fonts-droid-fallback libvlc-dev libvlccore-dev vlc-bin texinfo premake4 golang libssl-dev curl patchelf xmlstarlet default-jre xsltproc libvpx-dev rdfind
 ```
 
 ### Building EmuELEC

--- a/packages/linux-firmware/kernel-firmware/package.mk
+++ b/packages/linux-firmware/kernel-firmware/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="kernel-firmware"
 PKG_VERSION="20240811"
-PKG_SHA256="d845252e0b0ce2f5dfabc22926cd70a939993329dc1b0c33ffc0c802f27c4e10"
+PKG_SHA256="58f1a14b800e3d1967986197d83c81f1ad14b7898a557133c58df0c02c538082"
 PKG_LICENSE="other"
 PKG_SITE="https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/"
 PKG_URL="https://cdn.kernel.org/pub/linux/kernel/firmware/linux-firmware-${PKG_VERSION}.tar.xz"

--- a/packages/linux-firmware/kernel-firmware/package.mk
+++ b/packages/linux-firmware/kernel-firmware/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kernel-firmware"
-PKG_VERSION="20231030"
-PKG_SHA256="c98d200fc4a3120de1a594713ce34e135819dff23e883a4ed387863ba25679c7"
+PKG_VERSION="20240811"
+PKG_SHA256="d845252e0b0ce2f5dfabc22926cd70a939993329dc1b0c33ffc0c802f27c4e10"
 PKG_LICENSE="other"
 PKG_SITE="https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/"
 PKG_URL="https://cdn.kernel.org/pub/linux/kernel/firmware/linux-firmware-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
This pull request includes an update to the `kernel-firmware` package version and its associated SHA256 checksum.

* Updated `PKG_VERSION` to `20240811` in `packages/linux-firmware/kernel-firmware/package.mk`.
* Updated `PKG_SHA256` to `d845252e0b0ce2f5dfabc22926cd70a939993329dc1b0c33ffc0c802f27c4e10` in `packages/linux-firmware/kernel-firmware/package.mk`.