### PR TITLE
update apache ant to 1.10.14

### DIFF
--- a/packages/addons/addon-depends/jre-depends/apache-ant/package.mk
+++ b/packages/addons/addon-depends/jre-depends/apache-ant/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="apache-ant"
-PKG_VERSION="1.10.13"
-PKG_SHA256="de0a860bf339e6975558f426772a6aa2c6ae0856215dd9aaf57aa2476d665664"
+PKG_VERSION="1.10.14"
+PKG_SHA256="a0456ecbf934b41dca74747413f2da7eafe40355fbdf5bfd38d8f3713dd828cd"
 PKG_LICENSE="Apache License 2.0"
 PKG_SITE="https://ant.apache.org/"
 PKG_URL="https://downloads.apache.org/ant/binaries/${PKG_NAME}-${PKG_VERSION}-bin.tar.xz"


### PR DESCRIPTION
This pull request includes an update to the `apache-ant` package in the `packages/addons/addon-depends/jre-depends` directory. The most significant change is the update of the package version and its corresponding SHA-256 checksum.

Version update:

* [`packages/addons/addon-depends/jre-depends/apache-ant/package.mk`](diffhunk://#diff-1f18ba433dc8c9f49027b43e114d2e7e4647ca35be7eb22db1e8fda9b4e2d6e3L6-R7): Updated `PKG_VERSION` from `1.10.13` to `1.10.14` and updated `PKG_SHA256` to match the new version.