### PR TITLE
dev - yabasanshiroSA - auto gamepad - analog fix

### DIFF
--- a/packages/sx05re/emulators/yabasanshiroSA/scripts/set_yabasanshiro_joy.sh
+++ b/packages/sx05re/emulators/yabasanshiroSA/scripts/set_yabasanshiro_joy.sh
@@ -87,10 +87,10 @@ declare -A GC_BUTTONS=(
   [y]="x"
   [a]="b"
   [b]="a"
-  [leftshoulder]="z"
-  [rightshoulder]="c"
-  [lefttrigger]="l"
-  [righttrigger]="r"
+  [leftshoulder]="l"
+  [rightshoulder]="r"
+  [lefttrigger]="z"
+  [righttrigger]="c"
   #[leftstick]=""
   #[rightstick]=""
   [back]="select"
@@ -98,8 +98,10 @@ declare -A GC_BUTTONS=(
   #[guide]=""
   [leftx0]="analogx"
   [leftx1]="analogy"
+  [leftx2]="analogleft"
   [lefty0]="analogl"
   [lefty1]="analogr"
+  [lefty2]="analogright"
 )
 
 # Cleans all the inputs for the gamepad with name ${GAMEPAD} and player ${1}
@@ -160,8 +162,7 @@ set_pad() {
         fi
         if [[ "${BTN_TYPE}" == "a" ]]; then
           case ${BUTTON_INDEX} in
-            leftx|rightx|lefty|righty)
-              continue
+            leftx|lefty|rightx|righty)
               ;;
           esac
           [[ ! -z "${VAL}" ]] && echo -e "\t\t\"${GC_INDEX}\": { \"id\": ${VAL}, \"type\": \"${TYPE}\", \"value\": 1 }," >> ${CONFIG_TMP}
@@ -175,18 +176,12 @@ set_pad() {
             echo -e "\t\t\"${GC_INDEX}\": { \"id\": ${VAL}, \"type\": \"${TYPE}\", \"value\": -1 }," >> ${CONFIG_TMP}
             GC_INDEX="${GC_BUTTONS[${BUTTON_INDEX}1]}"
             echo -e "\t\t\"${GC_INDEX}\": { \"id\": ${VAL}, \"type\": \"${TYPE}\", \"value\": 1 }," >> ${CONFIG_TMP}
+            GC_INDEX="${GC_BUTTONS[${BUTTON_INDEX}2]}"
+            echo -e "\t\t\"${GC_INDEX}\": { \"id\": ${VAL}, \"type\": \"${TYPE}\", \"value\": 1 }," >> ${CONFIG_TMP}
             ;;
         esac
       fi      
   done
-
-  local AXIS="$( cat /tmp/sdljoytest.txt | grep "Joystick ${JOY_INDEX} Axes" | cut -d' ' -f4 | sed 's/^0*//' )"
-  if [[ ! -z "${AXIS}" ]]; then
-    local AXIS_LEFT=$(( AXIS - 2 ))
-    local AXIS_RIGHT=$(( AXIS - 1 ))
-    echo -e "\t\t\"analogleft\": { \"id\": ${AXIS_LEFT}, \"type\": \"axis\", \"value\": 0 }," >> ${CONFIG_TMP}
-    echo -e "\t\t\"analogright\": { \"id\": ${AXIS_RIGHT}, \"type\": \"axis\", \"value\": 0 }," >> ${CONFIG_TMP}
-  fi
 
   # remove last character
   sed -i '$ s/.$//' ${CONFIG_TMP}
@@ -212,4 +207,3 @@ echo "{" >> ${CONFIG}
 jc_get_players
 
 echo "}" >> ${CONFIG}
-


### PR DESCRIPTION
dev - yabasanshiroSA - auto gamepad - analog fix

Should fix analog controls for yabasanshiro SA.

To test SSH in and execute the following:
```
cd /emuelec/bin
wget https://raw.githubusercontent.com/EmuELEC/EmuELEC/dbc676dc0b5730ba6b3660f41c4a2b9cb3afc882/packages/sx05re/emulators/yabasanshiroSA/scripts/set_yabasanshiro_joy.sh
chmod -x /emuelec/bin/set_yabasanshiro_joy.sh
```
Then run the a game, make sure yabanshiro auto gamepad is enabled in ES Settings.
