### PR TITLE
retroarch.cfg updated and add 'Stella 2023' libretro core

### DIFF
--- a/packages/sx05re/emuelec-emulationstation/config/es_features.cfg
+++ b/packages/sx05re/emuelec-emulationstation/config/es_features.cfg
@@ -74,6 +74,7 @@
       <core name="snes9x2010" features="netplay, rewind, autosave, cheevos" />
       <core name="snes9x" features="netplay, rewind, autosave, cheevos" />
       <core name="stella" features="netplay, rewind, autosave, cheevos" />
+      <core name="stella2023" features="netplay, rewind, autosave, cheevos" />
       <core name="tgbdual" features="netplay, rewind, autosave" />
       <core name="tyrquake" features="netplay, rewind, autosave" />
       <core name="uae4arm" features="netplay, rewind, autosave" />

--- a/packages/sx05re/emuelec-emulationstation/config/es_systems.cfg
+++ b/packages/sx05re/emuelec-emulationstation/config/es_systems.cfg
@@ -191,7 +191,8 @@ This file will be replaced on any new update of EmuELEC-->
 			</emulator>
 			<emulator name="libretro">
 				<cores>
-					<core default="true">stella</core>
+					<core default="true">stella2023</core>
+					<core>stella</core>
 				</cores>
 			</emulator>
 		</emulators>

--- a/packages/sx05re/libretro/retroarch/package.mk
+++ b/packages/sx05re/libretro/retroarch/package.mk
@@ -109,87 +109,73 @@ makeinstall_target() {
   # General configuration
   sed -i -e "s/# libretro_directory =/libretro_directory = \"\/tmp\/cores\"/" ${INSTALL}/etc/retroarch.cfg
   sed -i -e "s/# libretro_info_path =/libretro_info_path = \"\/tmp\/cores\"/" ${INSTALL}/etc/retroarch.cfg
-  sed -i -e "s/# rgui_browser_directory =/rgui_browser_directory =\/storage\/roms/" ${INSTALL}/etc/retroarch.cfg
-  sed -i -e "s/# content_database_path =/content_database_path =\/tmp\/database\/rdb/" ${INSTALL}/etc/retroarch.cfg
-  sed -i -e "s/# playlist_directory =/playlist_directory =\/storage\/playlists/" ${INSTALL}/etc/retroarch.cfg
-  sed -i -e "s/# savefile_directory =/# savefile_directory =\/storage\/savefiles/" ${INSTALL}/etc/retroarch.cfg
-  sed -i -e "s/# savestate_directory =/savestate_directory =\/storage\/roms\/savestates/" ${INSTALL}/etc/retroarch.cfg
-  sed -i -e "s/# system_directory =/system_directory =\/storage\/roms\/bios/" ${INSTALL}/etc/retroarch.cfg
-  sed -i -e "s/# screenshot_directory =/screenshot_directory =\/storage\/roms\/screenshots/" ${INSTALL}/etc/retroarch.cfg
-  sed -i -e "s/# recording_output_directory =/recording_output_directory =\/storage\/roms\/mplayer\/retroarch/" ${INSTALL}/etc/retroarch.cfg
-  sed -i -e "s/# video_shader_dir =/video_shader_dir =\/tmp\/shaders/" ${INSTALL}/etc/retroarch.cfg
-  sed -i -e "s/# rgui_show_start_screen = true/rgui_show_start_screen = false/" ${INSTALL}/etc/retroarch.cfg
-  sed -i -e "s/# assets_directory =/assets_directory =\/tmp\/assets/" ${INSTALL}/etc/retroarch.cfg
-  sed -i -e "s/# overlay_directory =/overlay_directory =\/tmp\/overlays/" ${INSTALL}/etc/retroarch.cfg
-  sed -i -e "s/# cheat_database_path =/cheat_database_path =\/tmp\/database\/cht/" ${INSTALL}/etc/retroarch.cfg
-  sed -i -e "s/# menu_driver = \"rgui\"/menu_driver = \"ozone\"/" ${INSTALL}/etc/retroarch.cfg
+  sed -i -e "s/# rgui_browser_directory =/rgui_browser_directory = \"\/storage\/roms\"/" ${INSTALL}/etc/retroarch.cfg
+  sed -i -e "s/# content_database_path =/content_database_path = \"\/tmp\/database\/rdb\"/" ${INSTALL}/etc/retroarch.cfg
+  sed -i -e "s/# playlist_directory =/playlist_directory = \"\/storage\/playlists\"/" ${INSTALL}/etc/retroarch.cfg
+  sed -i -e "s/# savestate_directory =/savestate_directory = \"\/storage\/roms\/savestates\"/" ${INSTALL}/etc/retroarch.cfg
+  sed -i -e "s/# system_directory =/system_directory = \"\/storage\/roms\/bios\"/" ${INSTALL}/etc/retroarch.cfg
+  sed -i -e "s/# screenshot_directory =/screenshot_directory = \"\/storage\/roms\/screenshots\"/" ${INSTALL}/etc/retroarch.cfg
+  sed -i -e "s/# recording_output_directory =/recording_output_directory = \"\/storage\/roms\/mplayer\/retroarch\"/" ${INSTALL}/etc/retroarch.cfg
+  sed -i -e "s/# video_shader_dir =/video_shader_dir = \"\/tmp\/shaders\"/" ${INSTALL}/etc/retroarch.cfg
+  sed -i -e "s/# rgui_show_start_screen = true/rgui_show_start_screen = \"false\"/" ${INSTALL}/etc/retroarch.cfg
+  sed -i -e "s/# assets_directory =/assets_directory = \"\/tmp\/assets\"/" ${INSTALL}/etc/retroarch.cfg
+  sed -i -e "s/# overlay_directory =/overlay_directory = \"\/tmp\/overlays\"/" ${INSTALL}/etc/retroarch.cfg
+  sed -i -e "s/# cheat_database_path =/cheat_database_path = \"\/tmp\/database\/cht\"/" ${INSTALL}/etc/retroarch.cfg
  
   # Quick menu
-  echo "core_assets_directory =/storage/roms/downloads" >> ${INSTALL}/etc/retroarch.cfg
+  echo "core_assets_directory = \"/storage/roms/downloads\"" >> ${INSTALL}/etc/retroarch.cfg
   echo "quick_menu_show_undo_save_load_state = \"false\"" >> ${INSTALL}/etc/retroarch.cfg
-  echo "quick_menu_show_save_core_overrides = \"false\"" >> ${INSTALL}/etc/retroarch.cfg
-  echo "quick_menu_show_save_game_overrides = \"false\"" >> ${INSTALL}/etc/retroarch.cfg
-  echo "quick_menu_show_cheats = \"true\"" >> ${INSTALL}/etc/retroarch.cfg
   
   # Video
-  sed -i -e "s/# video_windowed_fullscreen = true/video_windowed_fullscreen = false/" ${INSTALL}/etc/retroarch.cfg
-  sed -i -e "s/# video_smooth = true/video_smooth = false/" ${INSTALL}/etc/retroarch.cfg
-  sed -i -e "s/# video_aspect_ratio_auto = false/video_aspect_ratio_auto = true/" ${INSTALL}/etc/retroarch.cfg
-  sed -i -e "s/# video_threaded = false/video_threaded = true/" ${INSTALL}/etc/retroarch.cfg
-  sed -i -e "s/# video_font_path =/video_font_path =\/usr\/share\/retroarch-assets\/xmb\/monochrome\/font.ttf/" ${INSTALL}/etc/retroarch.cfg
-  sed -i -e "s/# video_font_size = 48/video_font_size = 32/" ${INSTALL}/etc/retroarch.cfg
-  sed -i -e "s/# video_filter_dir =/video_filter_dir =\/usr\/share\/video_filters/" ${INSTALL}/etc/retroarch.cfg
-  sed -i -e "s/# video_gpu_screenshot = true/video_gpu_screenshot = false/" ${INSTALL}/etc/retroarch.cfg
-  sed -i -e "s/# video_fullscreen = false/video_fullscreen = true/" ${INSTALL}/etc/retroarch.cfg
+  sed -i -e "s/# video_windowed_fullscreen = true/video_windowed_fullscreen = \"false\"/" ${INSTALL}/etc/retroarch.cfg
+  sed -i -e "s/# video_aspect_ratio_auto = false/video_aspect_ratio_auto = \"true\"/" ${INSTALL}/etc/retroarch.cfg
+  sed -i -e "s/# video_threaded = false/video_threaded = \"true\"/" ${INSTALL}/etc/retroarch.cfg
+  sed -i -e "s/# video_font_path =/video_font_path = \"\/usr\/share\/retroarch-assets\/xmb\/monochrome\/font.ttf\"/" ${INSTALL}/etc/retroarch.cfg
+  sed -i -e "s/# video_filter_dir =/video_filter_dir = \"\/usr\/share\/video_filters\"/" ${INSTALL}/etc/retroarch.cfg
+  sed -i -e "s/# video_gpu_screenshot = true/video_gpu_screenshot = \"false\"/" ${INSTALL}/etc/retroarch.cfg
+  sed -i -e "s/# video_fullscreen = false/video_fullscreen = \"true\"/" ${INSTALL}/etc/retroarch.cfg
 
   # Audio
   sed -i -e "s/# audio_driver =/audio_driver = \"alsathread\"/" ${INSTALL}/etc/retroarch.cfg
-  sed -i -e "s/# audio_filter_dir =/audio_filter_dir =\/usr\/share\/audio_filters/" ${INSTALL}/etc/retroarch.cfg
+  sed -i -e "s/# audio_filter_dir =/audio_filter_dir = \"\/usr\/share\/audio_filters\"/" ${INSTALL}/etc/retroarch.cfg
   if [ "${PROJECT}" == "OdroidXU3" ]; then # workaround the 55fps bug
-    sed -i -e "s/# audio_out_rate = 48000/audio_out_rate = 44100/" ${INSTALL}/etc/retroarch.cfg
+    sed -i -e "s/# audio_out_rate = 48000/audio_out_rate = \"44100\"/" ${INSTALL}/etc/retroarch.cfg
   fi
 
   # Saving
   echo "savestate_thumbnail_enable = \"true\"" >> ${INSTALL}/etc/retroarch.cfg
   
   # Input
-  sed -i -e "s/# input_driver = sdl/input_driver = udev/" ${INSTALL}/etc/retroarch.cfg
-  sed -i -e "s/# input_max_users = 16/input_max_users = 5/" ${INSTALL}/etc/retroarch.cfg
-  sed -i -e "s/# input_autodetect_enable = true/input_autodetect_enable = true/" ${INSTALL}/etc/retroarch.cfg
-  sed -i -e "s/# joypad_autoconfig_dir =/joypad_autoconfig_dir = \/tmp\/joypads/" ${INSTALL}/etc/retroarch.cfg
-  sed -i -e "s/# input_remapping_directory =/input_remapping_directory = \/storage\/.config\/retroarch\/config\/remappings/" ${INSTALL}/etc/retroarch.cfg
-  sed -i -e "s/# input_menu_toggle_gamepad_combo = 0/input_menu_toggle_gamepad_combo = 2/" ${INSTALL}/etc/retroarch.cfg
-  sed -i -e "s/# all_users_control_menu = false/all_users_control_menu = true/" ${INSTALL}/etc/retroarch.cfg
+  sed -i -e "s/# input_driver = sdl/input_driver = \"udev\"/" ${INSTALL}/etc/retroarch.cfg
+  sed -i -e "s/# joypad_autoconfig_dir =/joypad_autoconfig_dir = \"\/tmp\/joypads\"/" ${INSTALL}/etc/retroarch.cfg
+  sed -i -e "s/# input_remapping_directory =/input_remapping_directory = \"\/storage\/.config\/retroarch\/config\/remappings\"/" ${INSTALL}/etc/retroarch.cfg
+  sed -i -e "s/# input_menu_toggle_gamepad_combo = 0/input_menu_toggle_gamepad_combo = \"2\"/" ${INSTALL}/etc/retroarch.cfg
+  sed -i -e "s/# all_users_control_menu = false/all_users_control_menu = \"true\"/" ${INSTALL}/etc/retroarch.cfg
 
   # Menu
-  sed -i -e "s/# menu_mouse_enable = false/menu_mouse_enable = false/" ${INSTALL}/etc/retroarch.cfg
-  sed -i -e "s/# menu_core_enable = true/menu_core_enable = true/" ${INSTALL}/etc/retroarch.cfg
-  sed -i -e "s/# thumbnails_directory =/thumbnails_directory = \/storage\/thumbnails/" ${INSTALL}/etc/retroarch.cfg
+  sed -i -e "s/# menu_mouse_enable = false/menu_mouse_enable = \"false\"/" ${INSTALL}/etc/retroarch.cfg
+  sed -i -e "s/# thumbnails_directory =/thumbnails_directory = \"\/storage\/thumbnails\"/" ${INSTALL}/etc/retroarch.cfg
   echo "menu_show_advanced_settings = \"false\"" >> ${INSTALL}/etc/retroarch.cfg
   echo "menu_wallpaper_opacity = \"1.0\"" >> ${INSTALL}/etc/retroarch.cfg
   echo "content_show_images = \"false\"" >> ${INSTALL}/etc/retroarch.cfg
-  echo "content_show_music = \"false\"" >> ${INSTALL}/etc/retroarch.cfg
   echo "content_show_video = \"false\"" >> ${INSTALL}/etc/retroarch.cfg
 
   # Updater
   if [ "${ARCH}" == "arm" ]; then
-    sed -i -e "s/# core_updater_buildbot_url = \"http:\/\/buildbot.libretro.com\"/core_updater_buildbot_url = \"http:\/\/buildbot.libretro.com\/nightly\/linux\/armhf\/latest\/\"/" ${INSTALL}/etc/retroarch.cfg
+    sed -i -e "s/# core_updater_buildbot_url = \"http:\/\/buildbot.libretro.com\"/core_updater_buildbot_cores_url = \"http:\/\/buildbot.libretro.com\/nightly\/linux\/armhf\/latest\/\"/" ${INSTALL}/etc/retroarch.cfg
   fi
   
   # Playlists
   echo "playlist_names = \"${RA_PLAYLIST_NAMES}\"" >> ${INSTALL}/etc/retroarch.cfg
   echo "playlist_cores = \"${RA_PLAYLIST_CORES}\"" >> ${INSTALL}/etc/retroarch.cfg
   echo "playlist_entry_rename = \"false\"" >> ${INSTALL}/etc/retroarch.cfg
-  echo "playlist_entry_remove = \"false\"" >> ${INSTALL}/etc/retroarch.cfg
+  echo "playlist_entry_remove_enable = \"2\"" >> ${INSTALL}/etc/retroarch.cfg
 
   #emuelec
-  sed -i -e "s/.*core_updater_buildbot_url =.*/core_updater_buildbot_url = \"http:\/\/dontupdatecores\"/" ${INSTALL}/etc/retroarch.cfg
-  sed -i -e "s/# input_hotkey_block_delay = \"5\"/input_hotkey_block_delay = \"5\"/" ${INSTALL}/etc/retroarch.cfg
-  sed -i -e "s/# menu_show_core_updater = true/\# DONT UPDATE CORES IT WILL BREAK EMUELEC! \n menu_show_core_updater = false/" ${INSTALL}/etc/retroarch.cfg
-  sed -i -e "s/# menu_show_online_updater = true/menu_show_online_updater = true/" ${INSTALL}/etc/retroarch.cfg
-  sed -i -e "s/# input_overlay_opacity = 1.0/input_overlay_opacity = 0.15/" ${INSTALL}/etc/retroarch.cfg
-  sed -i -e "s/# audio_volume = 0.0/audio_volume = "0.000000"/" ${INSTALL}/etc/retroarch.cfg
-  sed -i -e "s/# cache_directory =/cache_directory = \/tmp\/cache/" ${INSTALL}/etc/retroarch.cfg
+  sed -i -e "s/.*core_updater_buildbot_url =.*/core_updater_buildbot_cores_url = \"http:\/\/dontupdatecores\/\"/" ${INSTALL}/etc/retroarch.cfg
+  sed -i -e "s/# menu_show_core_updater = true/\# DONT UPDATE CORES IT WILL BREAK EMUELEC!\nmenu_show_core_updater = \"false\"/" ${INSTALL}/etc/retroarch.cfg
+  sed -i -e "s/# input_overlay_opacity = 1.0/input_overlay_opacity = \"0.15\"/" ${INSTALL}/etc/retroarch.cfg
+  sed -i -e "s/# cache_directory =/cache_directory = \"\/tmp\/cache\"/" ${INSTALL}/etc/retroarch.cfg
   echo "user_language = \"0\"" >> ${INSTALL}/etc/retroarch.cfg
   echo "menu_show_shutdown = \"false\"" >> ${INSTALL}/etc/retroarch.cfg
   echo "menu_show_reboot = \"false\"" >> ${INSTALL}/etc/retroarch.cfg
@@ -197,21 +183,28 @@ makeinstall_target() {
   echo "input_player2_analog_dpad_mode = \"1\"" >> ${INSTALL}/etc/retroarch.cfg
   echo "input_player3_analog_dpad_mode = \"1\"" >> ${INSTALL}/etc/retroarch.cfg
   echo "input_player4_analog_dpad_mode = \"1\"" >> ${INSTALL}/etc/retroarch.cfg
+  echo "input_player5_analog_dpad_mode = \"1\"" >> ${INSTALL}/etc/retroarch.cfg
+  echo "input_player6_analog_dpad_mode = \"1\"" >> ${INSTALL}/etc/retroarch.cfg
+  echo "input_player7_analog_dpad_mode = \"1\"" >> ${INSTALL}/etc/retroarch.cfg
+  echo "input_player8_analog_dpad_mode = \"1\"" >> ${INSTALL}/etc/retroarch.cfg
   echo "savefiles_in_content_dir = \"true\"" >> ${INSTALL}/etc/retroarch.cfg
-  echo "savestates_in_content_dir = \"false\"" >> ${INSTALL}/etc/retroarch.cfg
   echo "menu_show_restart_retroarch = \"false\"" >> ${INSTALL}/etc/retroarch.cfg
   echo "menu_show_quit_retroarch = \"true\"" >> ${INSTALL}/etc/retroarch.cfg
+
+  # Extra settings
+  sed -i -e "s/# cheevos_unlock_sound_enable = false/cheevos_unlock_sound_enable = \"true\"/" ${INSTALL}/etc/retroarch.cfg
+  echo -e '\n#extra settings\nmenu_show_load_content_animation = "false"\nnotification_show_autoconfig = "false"\nnotification_show_config_override_load = "false"\nnotification_show_remap_load = "false"\nquick_menu_show_start_recording = "false"\nquick_menu_show_start_streaming = "false"\nquit_press_twice = "false"' >> ${INSTALL}/etc/retroarch.cfg
   
 if [ "${DEVICE}" == "OdroidGoAdvance" ] || [ "${DEVICE}" == "GameForce" ]; then
-    echo "xmb_layout = 2" >> ${INSTALL}/etc/retroarch.cfg
-    echo "menu_widget_scale_auto = false" >> ${INSTALL}/etc/retroarch.cfg
-    echo "menu_widget_scale_factor = 2.00" >> ${INSTALL}/etc/retroarch.cfg
-    echo "menu_scale_factor = 1.000000" >> ${INSTALL}/etc/retroarch.cfg
-    echo "video_font_size = 12.000000" >> ${INSTALL}/etc/retroarch.cfg
-    echo "menu_rgui_shadows = true" >> ${INSTALL}/etc/retroarch.cfg
-    echo "rgui_aspect_ratio = 6" >> ${INSTALL}/etc/retroarch.cfg
-    echo "rgui_inline_thumbnails = true" >> ${INSTALL}/etc/retroarch.cfg
-    echo "input_max_users = 1" >> ${INSTALL}/etc/retroarch.cfg
+    echo "xmb_layout = \"2\"" >> ${INSTALL}/etc/retroarch.cfg
+    echo "menu_widget_scale_auto = \"false\"" >> ${INSTALL}/etc/retroarch.cfg
+    echo "menu_widget_scale_factor = \"2.0\"" >> ${INSTALL}/etc/retroarch.cfg
+    echo "menu_scale_factor = \"1.0\"" >> ${INSTALL}/etc/retroarch.cfg
+    echo "video_font_size = \"12.0\"" >> ${INSTALL}/etc/retroarch.cfg
+    echo "menu_rgui_shadows = \"true\"" >> ${INSTALL}/etc/retroarch.cfg
+    echo "rgui_aspect_ratio = \"6\"" >> ${INSTALL}/etc/retroarch.cfg
+    echo "rgui_inline_thumbnails = \"true\"" >> ${INSTALL}/etc/retroarch.cfg
+    echo "input_max_users = \"1\"" >> ${INSTALL}/etc/retroarch.cfg
 fi
 
   mkdir -p ${INSTALL}/usr/config/retroarch/

--- a/packages/sx05re/libretro/stella2023/package.mk
+++ b/packages/sx05re/libretro/stella2023/package.mk
@@ -1,0 +1,45 @@
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2009-2012 Stephan Raue (stephan@openelec.tv)
+#
+#  This Program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2, or (at your option)
+#  any later version.
+#
+#  This Program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.tv; see the file COPYING.  If not, write to
+#  the Free Software Foundation, 51 Franklin Street, Suite 500, Boston, MA 02110, USA.
+#  http://www.gnu.org/copyleft/gpl.html
+################################################################################
+
+PKG_NAME="stella2023"
+PKG_VERSION="ca34413ccc6bd684013f2befff3d108ca1e51821"
+PKG_REV="1"
+PKG_LICENSE="GPL2"
+PKG_SITE="https://github.com/libretro/stella2023"
+PKG_URL="${PKG_SITE}/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_PRIORITY="optional"
+PKG_SECTION="libretro"
+PKG_SHORTDESC="Port of Stella to libretro."
+PKG_LONGDESC="Stella is a multi-platform Atari 2600 VCS emulator released under the GNU General Public License (GPL)."
+PKG_TOOLCHAIN="make"
+
+pre_configure_target() {
+if [ "${ARCH}" == "arm" ]; then
+PKG_MAKE_OPTS_TARGET=" -C ${PKG_BUILD}/src/os/libretro -f Makefile platform=emuelec"
+else
+PKG_MAKE_OPTS_TARGET=" -C ${PKG_BUILD}/src/os/libretro -f Makefile platform=emuelec-arm64"
+fi
+}
+
+makeinstall_target() {
+  mkdir -p ${INSTALL}/usr/lib/libretro
+  cp ${PKG_BUILD}/src/os/libretro/stella2023_libretro.so ${INSTALL}/usr/lib/libretro/
+}

--- a/packages/sx05re/libretro/stella2023/patches/stella-01-emuelec-platform.patch
+++ b/packages/sx05re/libretro/stella2023/patches/stella-01-emuelec-platform.patch
@@ -1,0 +1,30 @@
+--- a/src/os/libretro/Makefile
++++ b/src/os/libretro/Makefile
+@@ -137,6 +137,27 @@
+       endif
+    endif
+ 
++# EmuELEC for Amlogic devices
++else ifeq ($(platform), emuelec)
++   TARGET := $(TARGET_NAME)_libretro.so
++   fpic := -fPIC
++   SHARED := -shared -Wl,--version-script=link.T -Wl,--no-undefined
++   CXXFLAGS += -lpthread -marm -mtune=cortex-a53 -mfpu=neon-vfpv4 -mfloat-abi=hard -march=armv7ve -DARM
++   LDFLAGS += -lpthread -static-libgcc -lstdc++
++   HAVE_NEON = 1
++   ARCH = arm
++   BUILTIN_GPU = neon
++   USE_DYNAREC = 1
++else ifeq ($(platform), emuelec-arm64)
++   TARGET := $(TARGET_NAME)_libretro.so
++   fpic := -fPIC
++   SHARED := -shared -Wl,--version-script=link.T -Wl,--no-undefined
++   CXXFLAGS += -lpthread -DARM64
++   LDFLAGS += -lpthread -static-libgcc -lstdc++
++   ARCH = arm64
++   USE_DYNAREC = 1
++
++
+ # iOS
+ else ifneq (,$(findstring ios,$(platform)))
+    CXXFLAGS += $(LTO) $(PTHREAD_FLAGS) -stdlib=libc++


### PR DESCRIPTION
I updated some parameters in the "retroarch.cfg" file that were already outdated compared to the most recent versions of RetroArch (e.g. "core_updater_buildbot_url" --> "core_updater_buildbot_cores_url", and "playlist_entry_remove = false --> "playlist_entry_remove_enable = 2"), removed some redundancies, and added the "Stella 2023" libretro core and made it the default for the Atari 2600 system, since the most recent commits of the "Stella" core are presenting a red error screen when exiting any game.