### PR TITLE
'retroarch.cfg' fixed and add Atari 2600 'Stella 2023' libretro core

### DIFF
--- a/distributions/EmuELEC/options
+++ b/distributions/EmuELEC/options
@@ -341,6 +341,7 @@ snes9x2005_plus \
 snes9x2010 \
 spring \
 stella \
+stella2023 \
 tgbdual \
 tic-80 \
 tyrquake \

--- a/packages/sx05re/emuelec-emulationstation/config/es_features.cfg
+++ b/packages/sx05re/emuelec-emulationstation/config/es_features.cfg
@@ -74,6 +74,7 @@
       <core name="snes9x2010" features="netplay, rewind, autosave, cheevos" />
       <core name="snes9x" features="netplay, rewind, autosave, cheevos" />
       <core name="stella" features="netplay, rewind, autosave, cheevos" />
+      <core name="stella2023" features="netplay, rewind, autosave, cheevos" />
       <core name="tgbdual" features="netplay, rewind, autosave" />
       <core name="tyrquake" features="netplay, rewind, autosave" />
       <core name="uae4arm" features="netplay, rewind, autosave" />

--- a/packages/sx05re/emuelec-emulationstation/config/es_systems.cfg
+++ b/packages/sx05re/emuelec-emulationstation/config/es_systems.cfg
@@ -191,7 +191,8 @@ This file will be replaced on any new update of EmuELEC-->
 			</emulator>
 			<emulator name="libretro">
 				<cores>
-					<core default="true">stella</core>
+					<core default="true">stella2023</core>
+					<core>stella</core>
 				</cores>
 			</emulator>
 		</emulators>
@@ -1701,7 +1702,7 @@ This file will be replaced on any new update of EmuELEC-->
 		<release>1990</release>
 		<hardware>portable</hardware>
 		<path>/storage/roms/gamegear</path>
-		<extension>.bin .BIN .gg .GG .zip .ZIP .7z .7Z</extension>
+		<extension>.bin .BIN .gg .GG .sms .SMS .zip .ZIP .7z .7Z</extension>
 		<command>emuelecRunEmu.sh %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers="%CONTROLLERSCONFIG%"</command>
 		<platform>gamegear</platform>
 		<theme>gamegear</theme>

--- a/packages/sx05re/libretro/retroarch/package.mk
+++ b/packages/sx05re/libretro/retroarch/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="retroarch"
-PKG_VERSION="c94e4cff856b4f5ce02e15e3321650e62548e819"
+PKG_VERSION="5365639a367790e60c317f3007c222651de1ed08"
 PKG_SITE="https://github.com/libretro/RetroArch"
 PKG_URL="${PKG_SITE}.git"
 PKG_LICENSE="GPLv3"
@@ -173,17 +173,17 @@ makeinstall_target() {
 
   # Updater
   if [ "${ARCH}" == "arm" ]; then
-    sed -i -e "s/# core_updater_buildbot_url = \"http:\/\/buildbot.libretro.com\"/core_updater_buildbot_url = \"http:\/\/buildbot.libretro.com\/nightly\/linux\/armhf\/latest\/\"/" ${INSTALL}/etc/retroarch.cfg
+    sed -i -e "s/# core_updater_buildbot_url = \"http:\/\/buildbot.libretro.com\"/core_updater_buildbot_cores_url = \"http:\/\/buildbot.libretro.com\/nightly\/linux\/armhf\/latest\/\"/" ${INSTALL}/etc/retroarch.cfg
   fi
   
   # Playlists
   echo "playlist_names = \"${RA_PLAYLIST_NAMES}\"" >> ${INSTALL}/etc/retroarch.cfg
   echo "playlist_cores = \"${RA_PLAYLIST_CORES}\"" >> ${INSTALL}/etc/retroarch.cfg
   echo "playlist_entry_rename = \"false\"" >> ${INSTALL}/etc/retroarch.cfg
-  echo "playlist_entry_remove = \"false\"" >> ${INSTALL}/etc/retroarch.cfg
+  echo "playlist_entry_remove_enable = \"2\"" >> ${INSTALL}/etc/retroarch.cfg
 
   #emuelec
-  sed -i -e "s/.*core_updater_buildbot_url =.*/core_updater_buildbot_url = \"http:\/\/dontupdatecores\"/" ${INSTALL}/etc/retroarch.cfg
+  sed -i -e "s/.*core_updater_buildbot_url =.*/core_updater_buildbot_cores_url = \"http:\/\/dontupdatecores\"/" ${INSTALL}/etc/retroarch.cfg
   sed -i -e "s/# input_hotkey_block_delay = \"5\"/input_hotkey_block_delay = \"5\"/" ${INSTALL}/etc/retroarch.cfg
   sed -i -e "s/# menu_show_core_updater = true/\# DONT UPDATE CORES IT WILL BREAK EMUELEC! \n menu_show_core_updater = false/" ${INSTALL}/etc/retroarch.cfg
   sed -i -e "s/# menu_show_online_updater = true/menu_show_online_updater = true/" ${INSTALL}/etc/retroarch.cfg

--- a/packages/sx05re/libretro/stella2023/package.mk
+++ b/packages/sx05re/libretro/stella2023/package.mk
@@ -1,0 +1,45 @@
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2009-2012 Stephan Raue (stephan@openelec.tv)
+#
+#  This Program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2, or (at your option)
+#  any later version.
+#
+#  This Program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.tv; see the file COPYING.  If not, write to
+#  the Free Software Foundation, 51 Franklin Street, Suite 500, Boston, MA 02110, USA.
+#  http://www.gnu.org/copyleft/gpl.html
+################################################################################
+
+PKG_NAME="stella2023"
+PKG_VERSION="ca34413ccc6bd684013f2befff3d108ca1e51821"
+PKG_REV="1"
+PKG_LICENSE="GPL2"
+PKG_SITE="https://github.com/libretro/stella2023"
+PKG_URL="${PKG_SITE}/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_PRIORITY="optional"
+PKG_SECTION="libretro"
+PKG_SHORTDESC="Port of Stella to libretro."
+PKG_LONGDESC="Stella is a multi-platform Atari 2600 VCS emulator released under the GNU General Public License (GPL)."
+PKG_TOOLCHAIN="make"
+
+pre_configure_target() {
+if [ "${ARCH}" == "arm" ]; then
+PKG_MAKE_OPTS_TARGET=" -C ${PKG_BUILD}/src/os/libretro -f Makefile platform=emuelec"
+else
+PKG_MAKE_OPTS_TARGET=" -C ${PKG_BUILD}/src/os/libretro -f Makefile platform=emuelec-arm64"
+fi
+}
+
+makeinstall_target() {
+  mkdir -p ${INSTALL}/usr/lib/libretro
+  cp ${PKG_BUILD}/src/os/libretro/stella2023_libretro.so ${INSTALL}/usr/lib/libretro/
+}

--- a/packages/sx05re/libretro/stella2023/patches/stella-01-emuelec-platform.patch
+++ b/packages/sx05re/libretro/stella2023/patches/stella-01-emuelec-platform.patch
@@ -1,0 +1,30 @@
+--- a/src/os/libretro/Makefile
++++ b/src/os/libretro/Makefile
+@@ -137,6 +137,27 @@
+       endif
+    endif
+ 
++# EmuELEC for Amlogic devices
++else ifeq ($(platform), emuelec)
++   TARGET := $(TARGET_NAME)_libretro.so
++   fpic := -fPIC
++   SHARED := -shared -Wl,--version-script=link.T -Wl,--no-undefined
++   CXXFLAGS += -lpthread -marm -mtune=cortex-a53 -mfpu=neon-vfpv4 -mfloat-abi=hard -march=armv7ve -DARM
++   LDFLAGS += -lpthread -static-libgcc -lstdc++
++   HAVE_NEON = 1
++   ARCH = arm
++   BUILTIN_GPU = neon
++   USE_DYNAREC = 1
++else ifeq ($(platform), emuelec-arm64)
++   TARGET := $(TARGET_NAME)_libretro.so
++   fpic := -fPIC
++   SHARED := -shared -Wl,--version-script=link.T -Wl,--no-undefined
++   CXXFLAGS += -lpthread -DARM64
++   LDFLAGS += -lpthread -static-libgcc -lstdc++
++   ARCH = arm64
++   USE_DYNAREC = 1
++
++
+ # iOS
+ else ifneq (,$(findstring ios,$(platform)))
+    CXXFLAGS += $(LTO) $(PTHREAD_FLAGS) -stdlib=libc++


### PR DESCRIPTION
I fixed two parameters in the "retroarch.cfg" file that were changed in the latest versions of RetroArch, and added the "Stella 2023" libretro core, since, in the latest commits, the default "Stella" core is showing a red screen when exiting any game.