### PR TITLE
Updated show_splash.sh and emuelec.conf / added multiple options for loading and exit splash screens

### DIFF
--- a/packages/sx05re/emuelec/bin/show_splash.sh
+++ b/packages/sx05re/emuelec/bin/show_splash.sh
@@ -25,8 +25,19 @@ if [ -f "/storage/roms/splash/intro.mp4" ]; then
     VIDEOSPLASH="/storage/roms/splash/intro.mp4"
 fi
 
+# we make sure the platform is all lowercase
 PLATFORM=${PLATFORM,,}
 PLAYER="ffplay"
+
+case ${PLATFORM} in
+ "arcade"|"fba"|"fbn"|"neogeo"|"mame"|cps*)
+   PLATFORM="arcade"
+  ;;
+ "retropie"|"setup")
+   # fbterm does not like the splash screen 
+   exit 0
+  ;;
+esac
 
 MODE=`get_resolution`
 
@@ -58,11 +69,22 @@ if [ "${ACTION_TYPE}" == "intro" ]; then
     if [[ "${MODE}" == *"x"* ]]; then
         SPLASH="/storage/.config/splash/splash-std.png"
     fi
+
 elif [ "${ACTION_TYPE}" == "exit" ]; then
     EXITVIDEO="/storage/roms/splash/exitvideo.mp4"
     EXITSPLASH="/storage/roms/splash/exitsplash.png"
+    CUSTOM_EXIT_VIDEO=$(get_ee_setting "ee_customexitsplashvideo")
+    CUSTOM_EXIT_VIDEO_ENABLED=$(get_ee_setting "ee_customexitsplashvideo.enabled")
+    CUSTOM_EXIT_IMAGE=$(get_ee_setting "ee_customexitsplashimage")
+    CUSTOM_EXIT_IMAGE_ENABLED=$(get_ee_setting "ee_customexitsplashimage.enabled")
 
-    if [[ $(get_ee_setting "ee_exitvideo.enabled") == "1" ]] && [[ -f "${EXITVIDEO}" ]]; then
+    if [[ "${CUSTOM_EXIT_VIDEO_ENABLED}" == "1" ]] && [[ -f "${CUSTOM_EXIT_VIDEO}" ]]; then
+        SPLASH="${CUSTOM_EXIT_VIDEO}"
+        VIDEO=1
+    elif [[ "${CUSTOM_EXIT_IMAGE_ENABLED}" == "1" ]] && [[ -f "${CUSTOM_EXIT_IMAGE}" ]]; then
+        SPLASH="${CUSTOM_EXIT_IMAGE}"
+        VIDEO=0
+    elif [[ $(get_ee_setting "ee_exitvideo.enabled") == "1" ]] && [[ -f "${EXITVIDEO}" ]]; then
         SPLASH="${EXITVIDEO}"
         VIDEO=1
     elif [[ $(get_ee_setting "ee_exitsplashimage.enabled") == "1" ]] && [[ -f "${EXITSPLASH}" ]]; then
@@ -75,46 +97,120 @@ elif [ "${ACTION_TYPE}" == "exit" ]; then
         fi
         VIDEO=0
     fi
+
 elif [ "${ACTION_TYPE}" == "blank" ]; then
     SPLASH=${BLANKSPLASH}
-elif [ "${ACTION_TYPE}" == "gameloading" ]; then
-    GAMELOADINGSPLASH="/storage/.config/splash/loading-game.png"
-    GAMELOADINGVIDEO="/storage/roms/splash/${PLATFORM}/launching.mp4"
-    GLOBALGAMELOADINGVIDEO="/storage/roms/splash/launching.mp4"
-    GLOBALGAMELOADINGIMAGE="/storage/roms/splash/launching.png"
-	RANDOMSYSTEMVIDEO=$(get_random_video "/storage/roms/splash/${PLATFORM}")
-	RANDOMVIDEOFILE=$(get_random_video "/storage/roms/splash/video")
 
-    if [[ $(get_ee_setting "ee_systemloadingvideo.enabled") == "1" ]] && [[ -f "${GAMELOADINGVIDEO}" ]]; then
-        SPLASH="${GAMELOADINGVIDEO}"
-        VIDEO=1
-    elif [[ $(get_ee_setting "ee_randomsystemvideo.enabled") == "1" ]] && [[ -n "${RANDOMSYSTEMVIDEO}" ]]; then
-        SPLASH="${RANDOMSYSTEMVIDEO}"
-        VIDEO=1
-    elif [[ $(get_ee_setting "ee_randomloadingvideo.enabled") == "1" ]] && [[ -n "${RANDOMVIDEOFILE}" ]]; then
-        SPLASH="${RANDOMVIDEOFILE}"
-        VIDEO=1
-    elif [[ $(get_ee_setting "ee_standardloadingvideo.enabled") == "1" ]] && [[ -f "${GLOBALGAMELOADINGVIDEO}" ]]; then
-        SPLASH="${GLOBALGAMELOADINGVIDEO}"
-        VIDEO=1
-    elif [[ $(get_ee_setting "ee_randomimage.enabled") == "1" ]]; then
-        SPLASH=$(get_random_splash "${RANDOMSPLASHDIR}")
-    elif [[ $(get_ee_setting "ee_randomsystemimage.enabled") == "1" ]]; then
-        SPLASH=$(get_random_splash "${PLATFORMSPLASHDIR}")
-    elif [[ $(get_ee_setting "ee_systemsplashimage.enabled") == "1" ]]; then
-        SPLASH="${PLATFORMSPLASHDIR}/launching.png"
-    elif [[ $(get_ee_setting "ee_standardloadingimage.enabled") == "1" ]] && [[ -f "${GLOBALGAMELOADINGIMAGE}" ]]; then
-        SPLASH="${GLOBALGAMELOADINGIMAGE}"
-    elif [[ -f "${GLOBALGAMELOADINGVIDEO}" ]]; then
-        SPLASH="${GLOBALGAMELOADINGVIDEO}"
-        VIDEO=1
+elif [ "${ACTION_TYPE}" == "gameloading" ]; then
+    # Standard fallback
+    GAMELOADINGSPLASH="/storage/.config/splash/loading-game.png"
+    if [[ "${MODE}" == *"x"* ]]; then
+        GAMELOADINGSPLASH="/storage/.config/splash/loading-game-std.png"
     fi
 
-    if [[ -z "$SPLASH" ]]; then
-        SPLASH="$GAMELOADINGSPLASH"
+    ROMNAME=$(basename "${3%.*}")
+    SPLMAP="/emuelec/configs/bezels/arcademap.cfg"
+    SPLNAME=$(sed -n "/`echo ""${PLATFORM}"_"${ROMNAME}" = "`/p" "${SPLMAP}")
+    REALSPL="${SPLNAME#*\"}"
+    REALSPL="${REALSPL%\"*}"
+
+    [ ! -z "${ROMNAME}" ] && SPLASH1=$(find ${SPLASHDIR}/${PLATFORM} -iname "${ROMNAME}*.png" -maxdepth 1 | sort -V | head -n 1)
+    [ ! -z "${ROMNAME}" ] && SPLASHVID1=$(find ${SPLASHDIR}/${PLATFORM} -iname "${ROMNAME}*.mp4" -maxdepth 1 | sort -V | head -n 1)
+    [ ! -z "${REALSPL}" ] && SPLASH2=$(find ${SPLASHDIR}/${PLATFORM} -iname "${REALSPL}*.png" -maxdepth 1 | sort -V | head -n 1)
+    [ ! -z "${REALSPL}" ] && SPLASHVID2=$(find ${SPLASHDIR}/${PLATFORM} -iname "${REALSPL}*.mp4" -maxdepth 1 | sort -V | head -n 1)
+
+    SPLASH3="${SPLASHDIR}/${PLATFORM}/launching.png"
+    SPLASHVID3="${SPLASHDIR}/${PLATFORM}/launching.mp4"
+    SPLASH4="${SPLASHDIR}/${PLATFORM}.png"
+    SPLASHVID4="${SPLASHDIR}/${PLATFORM}.mp4"
+    SPLASH5="${SPLASHDIR}/launching.png"
+    SPLASHVID5="${SPLASHDIR}/launching.mp4"
+
+    if [ -f "${SPLASHVID1}" ]; then
+        SPLASH="${SPLASHVID1}"
+        VIDEO=1
+    elif [ -f "${SPLASH1}" ]; then
+        SPLASH="${SPLASH1}"
+        VIDEO=0
+    elif [ -f "${SPLASHVID2}" ]; then
+        SPLASH="${SPLASHVID2}"
+        VIDEO=1
+    elif [ -f "${SPLASH2}" ]; then
+        SPLASH="${SPLASH2}"
+        VIDEO=0
+    elif [ -f "${SPLASHVID3}" ]; then
+        SPLASH="${SPLASHVID3}"
+        VIDEO=1
+    elif [ -f "${SPLASH3}" ]; then
+        SPLASH="${SPLASH3}"
+        VIDEO=0
+    elif [ -f "${SPLASHVID4}" ]; then
+        SPLASH="${SPLASHVID4}"
+        VIDEO=1
+    elif [ -f "${SPLASH4}" ]; then
+        SPLASH="${SPLASH4}"
+        VIDEO=0
+    elif [ -f "${SPLASHVID5}" ]; then
+        SPLASH="${SPLASHVID5}"
+        VIDEO=1
+    elif [ -f "${SPLASH5}" ]; then
+        SPLASH="${SPLASH5}"
+        VIDEO=0
+    else
+        # Fallback auf konfigurierbare Optionen
+        GAMELOADINGVIDEO="/storage/roms/splash/${PLATFORM}/launching.mp4"
+        GLOBALGAMELOADINGVIDEO="/storage/roms/splash/launching.mp4"
+        GLOBALGAMELOADINGIMAGE="/storage/roms/splash/launching.png"
+        RANDOMSYSTEMVIDEO=$(get_random_video "/storage/roms/splash/${PLATFORM}")
+        RANDOMVIDEOFILE=$(get_random_video "/storage/roms/splash/video")
+
+        CUSTOM_GAME_VIDEO=$(get_ee_setting "ee_customsplashvideo")
+        CUSTOM_GAME_VIDEO_ENABLED=$(get_ee_setting "ee_customsplashvideo.enabled")
+        CUSTOM_GAME_IMAGE=$(get_ee_setting "ee_customsplashimage")
+        CUSTOM_GAME_IMAGE_ENABLED=$(get_ee_setting "ee_customsplashimage.enabled")
+
+        if [[ "${CUSTOM_GAME_VIDEO_ENABLED}" == "1" ]] && [[ -f "${CUSTOM_GAME_VIDEO}" ]]; then
+            SPLASH="${CUSTOM_GAME_VIDEO}"
+            VIDEO=1
+        elif [[ "${CUSTOM_GAME_IMAGE_ENABLED}" == "1" ]] && [[ -f "${CUSTOM_GAME_IMAGE}" ]]; then
+            SPLASH="${CUSTOM_GAME_IMAGE}"
+            VIDEO=0
+        elif [[ $(get_ee_setting "ee_systemloadingvideo.enabled") == "1" ]] && [[ -f "${GAMELOADINGVIDEO}" ]]; then
+            SPLASH="${GAMELOADINGVIDEO}"
+            VIDEO=1
+        elif [[ $(get_ee_setting "ee_randomsystemvideo.enabled") == "1" ]] && [[ -n "${RANDOMSYSTEMVIDEO}" ]]; then
+            SPLASH="${RANDOMSYSTEMVIDEO}"
+            VIDEO=1
+        elif [[ $(get_ee_setting "ee_randomloadingvideo.enabled") == "1" ]] && [[ -n "${RANDOMVIDEOFILE}" ]]; then
+            SPLASH="${RANDOMVIDEOFILE}"
+            VIDEO=1
+        elif [[ $(get_ee_setting "ee_standardloadingvideo.enabled") == "1" ]] && [[ -f "${GLOBALGAMELOADINGVIDEO}" ]]; then
+            SPLASH="${GLOBALGAMELOADINGVIDEO}"
+            VIDEO=1
+        elif [[ $(get_ee_setting "ee_randomimage.enabled") == "1" ]]; then
+            SPLASH=$(get_random_splash "${RANDOMSPLASHDIR}")
+            VIDEO=0
+        elif [[ $(get_ee_setting "ee_randomsystemimage.enabled") == "1" ]]; then
+            SPLASH=$(get_random_splash "${PLATFORMSPLASHDIR}")
+            VIDEO=0
+        elif [[ $(get_ee_setting "ee_systemsplashimage.enabled") == "1" ]]; then
+            SPLASH="${PLATFORMSPLASHDIR}/launching.png"
+            VIDEO=0
+        elif [[ $(get_ee_setting "ee_standardloadingimage.enabled") == "1" ]] && [[ -f "${GLOBALGAMELOADINGIMAGE}" ]]; then
+            SPLASH="${GLOBALGAMELOADINGIMAGE}"
+            VIDEO=0
+        elif [[ -f "${GLOBALGAMELOADINGVIDEO}" ]]; then
+            SPLASH="${GLOBALGAMELOADINGVIDEO}"
+            VIDEO=1
+        else
+            SPLASH="$GAMELOADINGSPLASH"
+            VIDEO=0
+        fi
     fi
 fi
 
+
+# Odroid Go Advance still does not support splash screens
 SS_DEVICE=0
 if [[ "${EE_DEVICE}" == "OdroidGoAdvance" ]] || [[ "${EE_DEVICE}" == "GameForce" ]]; then
   SS_DEVICE=1
@@ -141,6 +237,7 @@ if [[ ${VIDEO} != "1" ]] && [[ -f "/storage/.config/emuelec/configs/novideo" ]];
         ${PLAYER} -fs -autoexit ${SIZE} "${SPLASH}" > /dev/null 2>&1
     fi
 else
+# Show intro video
     if [[ "${ACTION_TYPE}" == "intro" ]]; then
         RND=$(get_ee_setting "ee_randombootvideo.enabled" == "1")
         if [ "${RND}" == 1 ]; then
@@ -152,19 +249,22 @@ else
     fi
 
     set_audio alsa
+	#[ -e /storage/.config/asound.conf ] && mv /storage/.config/asound.conf /storage/.config/asound.confs
     if [ ${SS_DEVICE} -eq 1 ]; then
         ${PLAYER} "${SPLASH}" > /dev/null 2>&1
     else
         ${PLAYER} -fs -autoexit ${SIZE} "${SPLASH}" > /dev/null 2>&1
     fi
 
-    # Nur bei intro novideo setzen
+
     if [[ "${ACTION_TYPE}" == "intro" ]]; then
         touch "/storage/.config/emuelec/configs/novideo"
+	#[ -e /storage/.config/asound.confs ] && mv /storage/.config/asound.confs /storage/.config/asound.conf
     fi
 fi
 
 fi
 
+# Wait for the time specified in ee_splash_delay setting in emuelec.conf
 SPLASHTIME=$(get_ee_setting ee_splash.delay)
 [ ! -z "${SPLASHTIME}" ] && sleep ${SPLASHTIME}

--- a/packages/sx05re/emuelec/bin/show_splash.sh
+++ b/packages/sx05re/emuelec/bin/show_splash.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2019-present SumavisionQ5 (https://github.com/SumavisionQ5)
+# Modifications by Shanti Gilbert (https://github.com/shantigilbert)
+
+# 12/07/2019 use mpv for all splash 
+# 19/01/2020 use ffplay for all splash 
+# 06/02/2020 move splash to roms folder and add global splash support
 
 . /etc/profile
 
@@ -34,25 +41,75 @@ get_random_splash() {
         echo ""
     fi
 }
+# Choose random mp4 file
+get_random_video() {
+    local dir="$1"
+    shopt -s nullglob
+    local files=("${dir}"/*.mp4)
+    if [[ ${#files[@]} -gt 0 ]]; then
+        echo "${files[RANDOM % ${#files[@]}]}"
+    else
+        echo ""
+    fi
+}
 
-if [ "${ACTION_TYPE}" == "intro" ] || [ "${ACTION_TYPE}" == "exit" ]; then
+if [ "${ACTION_TYPE}" == "intro" ]; then
     SPLASH=${DEFAULTSPLASH}
     if [[ "${MODE}" == *"x"* ]]; then
         SPLASH="/storage/.config/splash/splash-std.png"
+    fi
+elif [ "${ACTION_TYPE}" == "exit" ]; then
+    EXITVIDEO="/storage/roms/splash/exitvideo.mp4"
+    EXITSPLASH="/storage/roms/splash/exitsplash.png"
+
+    if [[ $(get_ee_setting "ee_exitvideo.enabled") == "1" ]] && [[ -f "${EXITVIDEO}" ]]; then
+        SPLASH="${EXITVIDEO}"
+        VIDEO=1
+    elif [[ $(get_ee_setting "ee_exitsplashimage.enabled") == "1" ]] && [[ -f "${EXITSPLASH}" ]]; then
+        SPLASH="${EXITSPLASH}"
+        VIDEO=0
+    else
+        SPLASH=${DEFAULTSPLASH}
+        if [[ "${MODE}" == *"x"* ]]; then
+            SPLASH="/storage/.config/splash/splash-std.png"
+        fi
+        VIDEO=0
     fi
 elif [ "${ACTION_TYPE}" == "blank" ]; then
     SPLASH=${BLANKSPLASH}
 elif [ "${ACTION_TYPE}" == "gameloading" ]; then
     GAMELOADINGSPLASH="/storage/.config/splash/loading-game.png"
-    
-    if [[ $(get_ee_setting "ee_randomimage.enabled") == "1" ]]; then
+    GAMELOADINGVIDEO="/storage/roms/splash/${PLATFORM}/launching.mp4"
+    GLOBALGAMELOADINGVIDEO="/storage/roms/splash/launching.mp4"
+    GLOBALGAMELOADINGIMAGE="/storage/roms/splash/launching.png"
+	RANDOMSYSTEMVIDEO=$(get_random_video "/storage/roms/splash/${PLATFORM}")
+	RANDOMVIDEOFILE=$(get_random_video "/storage/roms/splash/video")
+
+    if [[ $(get_ee_setting "ee_systemloadingvideo.enabled") == "1" ]] && [[ -f "${GAMELOADINGVIDEO}" ]]; then
+        SPLASH="${GAMELOADINGVIDEO}"
+        VIDEO=1
+    elif [[ $(get_ee_setting "ee_randomsystemvideo.enabled") == "1" ]] && [[ -n "${RANDOMSYSTEMVIDEO}" ]]; then
+        SPLASH="${RANDOMSYSTEMVIDEO}"
+        VIDEO=1
+    elif [[ $(get_ee_setting "ee_randomloadingvideo.enabled") == "1" ]] && [[ -n "${RANDOMVIDEOFILE}" ]]; then
+        SPLASH="${RANDOMVIDEOFILE}"
+        VIDEO=1
+    elif [[ $(get_ee_setting "ee_standardloadingvideo.enabled") == "1" ]] && [[ -f "${GLOBALGAMELOADINGVIDEO}" ]]; then
+        SPLASH="${GLOBALGAMELOADINGVIDEO}"
+        VIDEO=1
+    elif [[ $(get_ee_setting "ee_randomimage.enabled") == "1" ]]; then
         SPLASH=$(get_random_splash "${RANDOMSPLASHDIR}")
     elif [[ $(get_ee_setting "ee_randomsystemimage.enabled") == "1" ]]; then
         SPLASH=$(get_random_splash "${PLATFORMSPLASHDIR}")
     elif [[ $(get_ee_setting "ee_systemsplashimage.enabled") == "1" ]]; then
         SPLASH="${PLATFORMSPLASHDIR}/launching.png"
+    elif [[ $(get_ee_setting "ee_standardloadingimage.enabled") == "1" ]] && [[ -f "${GLOBALGAMELOADINGIMAGE}" ]]; then
+        SPLASH="${GLOBALGAMELOADINGIMAGE}"
+    elif [[ -f "${GLOBALGAMELOADINGVIDEO}" ]]; then
+        SPLASH="${GLOBALGAMELOADINGVIDEO}"
+        VIDEO=1
     fi
-    
+
     if [[ -z "$SPLASH" ]]; then
         SPLASH="$GAMELOADINGSPLASH"
     fi
@@ -69,29 +126,44 @@ fi
 declare -a RES=( ${MODE} )
 SIZE=" -x ${RES[0]} -y ${RES[1]}"
 
-[[ "${ACTION_TYPE}" != "intro" ]] && VIDEO=0 || VIDEO=$(get_ee_setting ee_bootvideo.enabled)
+# Fix: Set VIDEO only if not already set (especially for gameloading)
+if [[ "${ACTION_TYPE}" == "intro" ]]; then
+    VIDEO=$(get_ee_setting ee_bootvideo.enabled)
+elif [[ -z "$VIDEO" ]]; then
+    VIDEO=0
+fi
 
-if [[ -f "/storage/.config/emuelec/configs/novideo" ]] && [[ ${VIDEO} != "1" ]]; then
+
+if [[ ${VIDEO} != "1" ]] && [[ -f "/storage/.config/emuelec/configs/novideo" ]]; then
     if [ "${SS_DEVICE}" == 1 ]; then
         ${PLAYER} "${SPLASH}" > /dev/null 2>&1
     else
         ${PLAYER} -fs -autoexit ${SIZE} "${SPLASH}" > /dev/null 2>&1
     fi
 else
-    RND=$(get_ee_setting "ee_randombootvideo.enabled" == "1")
-    if [ "${RND}" == 1 ]; then
-        SPLASH=$(ls ${RANDOMVIDEO}/*.mp4 |sort -R |tail -1)
-        [[ -z "${SPLASH}" ]] && SPLASH="${VIDEOSPLASH}"
-    else
-        SPLASH="${VIDEOSPLASH}"
+    if [[ "${ACTION_TYPE}" == "intro" ]]; then
+        RND=$(get_ee_setting "ee_randombootvideo.enabled" == "1")
+        if [ "${RND}" == 1 ]; then
+            SPLASH=$(ls ${RANDOMVIDEO}/*.mp4 | sort -R | tail -1)
+            [[ -z "${SPLASH}" ]] && SPLASH="${VIDEOSPLASH}"
+        else
+            SPLASH="${VIDEOSPLASH}"
+        fi
     fi
+
     set_audio alsa
     if [ ${SS_DEVICE} -eq 1 ]; then
         ${PLAYER} "${SPLASH}" > /dev/null 2>&1
     else
         ${PLAYER} -fs -autoexit ${SIZE} "${SPLASH}" > /dev/null 2>&1
     fi
-    touch "/storage/.config/emuelec/configs/novideo"
+
+    # Nur bei intro novideo setzen
+    if [[ "${ACTION_TYPE}" == "intro" ]]; then
+        touch "/storage/.config/emuelec/configs/novideo"
+    fi
+fi
+
 fi
 
 SPLASHTIME=$(get_ee_setting ee_splash.delay)

--- a/packages/sx05re/emuelec/bin/show_splash.sh
+++ b/packages/sx05re/emuelec/bin/show_splash.sh
@@ -1,21 +1,15 @@
 #!/bin/bash
 
-# SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2019-present SumavisionQ5 (https://github.com/SumavisionQ5)
-# Modifications by Shanti Gilbert (https://github.com/shantigilbert)
-
-# 12/07/2019 use mpv for all splash 
-# 19/01/2020 use ffplay for all splash 
-# 06/02/2020 move splash to roms folder and add global splash support
-
 . /etc/profile
 
 ACTION_TYPE="${1}"
 PLATFORM="${2}"
 
-GAMELOADINGSPLASH="/storage/.config/splash/loading-game.png"
-BLANKSPLASH="/storage/.config/splash/blank.png"
+SPLASHDIR="/storage/roms/splash"
+RANDOMSPLASHDIR="${SPLASHDIR}/random"
+PLATFORMSPLASHDIR="${SPLASHDIR}/${PLATFORM}"
 DEFAULTSPLASH="/storage/.config/splash/splash-1080.png"
+BLANKSPLASH="/storage/.config/splash/blank.png"
 VIDEOSPLASH="/usr/config/splash/emuelec_intro_1080p.mp4"
 RANDOMVIDEO="/storage/roms/splash/introvideos"
 DURATION="5"
@@ -24,81 +18,46 @@ if [ -f "/storage/roms/splash/intro.mp4" ]; then
     VIDEOSPLASH="/storage/roms/splash/intro.mp4"
 fi
 
-# we make sure the platform is all lowercase
 PLATFORM=${PLATFORM,,}
 PLAYER="ffplay"
 
-case ${PLATFORM} in
- "arcade"|"fba"|"fbn"|"neogeo"|"mame"|cps*)
-   PLATFORM="arcade"
-  ;;
- "retropie"|"setup")
-   # fbterm does not like the splash screen 
-   exit 0
-  ;;
-esac
+MODE=`get_resolution`
 
-MODE=`get_resolution`;
+# Choose random PNG image
+get_random_splash() {
+    local dir="$1"
+    shopt -s nullglob
+    local files=("${dir}"/*.png)
+    if [[ ${#files[@]} -gt 0 ]]; then
+        echo "${files[RANDOM % ${#files[@]}]}"
+    else
+        echo ""
+    fi
+}
 
-SPLASHDIR="/storage/roms/splash"
-  
 if [ "${ACTION_TYPE}" == "intro" ] || [ "${ACTION_TYPE}" == "exit" ]; then
-	SPLASH=${DEFAULTSPLASH}
-  if [[ "${MODE}" == *"x"* ]]; then
-    SPLASH="/storage/.config/splash/splash-std.png"
-  fi
+    SPLASH=${DEFAULTSPLASH}
+    if [[ "${MODE}" == *"x"* ]]; then
+        SPLASH="/storage/.config/splash/splash-std.png"
+    fi
 elif [ "${ACTION_TYPE}" == "blank" ]; then
-  SPLASH=${BLANKSPLASH}
+    SPLASH=${BLANKSPLASH}
 elif [ "${ACTION_TYPE}" == "gameloading" ]; then
-  if [[ "${MODE}" == *"x"* ]]; then
-    GAMELOADINGSPLASH="/storage/.config/splash/loading-game-std.png"
-  fi
-
-	ROMNAME=$(basename "${3%.*}")
-	SPLMAP="/emuelec/configs/bezels/arcademap.cfg"
-	SPLNAME=$(sed -n "/`echo ""${PLATFORM}"_"${ROMNAME}" = "`/p" "${SPLMAP}")
-	REALSPL="${SPLNAME#*\"}"
-	REALSPL="${REALSPL%\"*}"
-[ ! -z "${ROMNAME}" ] && SPLASH1=$(find ${SPLASHDIR}/${PLATFORM} -iname "${ROMNAME}*.png" -maxdepth 1 | sort -V | head -n 1)
-[ ! -z "${ROMNAME}" ] && SPLASHVID1=$(find ${SPLASHDIR}/${PLATFORM} -iname "${ROMNAME}*.mp4" -maxdepth 1 | sort -V | head -n 1)
-[ ! -z "${REALSPL}" ] && SPLASH2=$(find ${SPLASHDIR}/${PLATFORM} -iname "${REALSPL}*.png" -maxdepth 1 | sort -V | head -n 1)
-[ ! -z "${REALSPL}" ] && SPLASHVID2=$(find ${SPLASHDIR}/${PLATFORM} -iname "${REALSPL}*.mp4" -maxdepth 1 | sort -V | head -n 1)
-
-SPLASH3="${SPLASHDIR}/${PLATFORM}/launching.png"
-SPLASHVID3="${SPLASHDIR}/${PLATFORM}/launching.mp4"
-
-SPLASH4="${SPLASHDIR}/${PLATFORM}.png"
-SPLASHVID4="${SPLASHDIR}/${PLATFORM}.mp4"
-
-SPLASH5="${SPLASHDIR}/launching.png"
-SPLASHVID5="${SPLASHDIR}/launching.mp4"
-	
-	if [ -f "${SPLASHVID1}" ]; then
-		SPLASH="${SPLASHVID1}"
-	elif [ -f "${SPLASH1}" ]; then
-		SPLASH="${SPLASH1}"
-	elif [ -f "${SPLASHVID2}" ]; then
-		SPLASH="${SPLASHVID2}"
-	elif [ -f "${SPLASH2}" ]; then
-		SPLASH="${SPLASH2}"
-	elif [ -f "${SPLASHVID3}" ]; then
-		SPLASH="${SPLASHVID3}"
-	elif [ -f "${SPLASH3}" ]; then
-		SPLASH="${SPLASH3}"
-	elif [ -f "${SPLASHVID4}" ]; then
-		SPLASH="${SPLASHVID4}"
-	elif [ -f "${SPLASH4}" ]; then
-		SPLASH="${SPLASH4}"
-	elif [ -f "${SPLASHVID5}" ]; then
-		SPLASH="${SPLASHVID5}"
-	elif [ -f "${SPLASH5}" ]; then
-		SPLASH="${SPLASH5}"
-	else
-		SPLASH="${GAMELOADINGSPLASH}"
-	fi
+    GAMELOADINGSPLASH="/storage/.config/splash/loading-game.png"
+    
+    if [[ $(get_ee_setting "ee_randomimage.enabled") == "1" ]]; then
+        SPLASH=$(get_random_splash "${RANDOMSPLASHDIR}")
+    elif [[ $(get_ee_setting "ee_randomsystemimage.enabled") == "1" ]]; then
+        SPLASH=$(get_random_splash "${PLATFORMSPLASHDIR}")
+    elif [[ $(get_ee_setting "ee_systemsplashimage.enabled") == "1" ]]; then
+        SPLASH="${PLATFORMSPLASHDIR}/launching.png"
+    fi
+    
+    if [[ -z "$SPLASH" ]]; then
+        SPLASH="$GAMELOADINGSPLASH"
+    fi
 fi
 
-# Odroid Go Advance still does not support splash screens
 SS_DEVICE=0
 if [[ "${EE_DEVICE}" == "OdroidGoAdvance" ]] || [[ "${EE_DEVICE}" == "GameForce" ]]; then
   SS_DEVICE=1
@@ -113,34 +72,27 @@ SIZE=" -x ${RES[0]} -y ${RES[1]}"
 [[ "${ACTION_TYPE}" != "intro" ]] && VIDEO=0 || VIDEO=$(get_ee_setting ee_bootvideo.enabled)
 
 if [[ -f "/storage/.config/emuelec/configs/novideo" ]] && [[ ${VIDEO} != "1" ]]; then
-	if [ "${ACTION_TYPE}" != "intro" ]; then
-	if [ "${SS_DEVICE}" == 1 ]; then
+    if [ "${SS_DEVICE}" == 1 ]; then
         ${PLAYER} "${SPLASH}" > /dev/null 2>&1
     else
         ${PLAYER} -fs -autoexit ${SIZE} "${SPLASH}" > /dev/null 2>&1
     fi
-
-	fi 
 else
-# Show intro video
-RND=$(get_ee_setting "ee_randombootvideo.enabled" == "1")
-if [ "${RND}" ==  1 ]; then
-    SPLASH=$(ls ${RANDOMVIDEO}/*.mp4 |sort -R |tail -1)
-    [[ -z "${SPLASH}" ]] && SPLASH="${VIDEOSPLASH}"
-else
-	SPLASH="${VIDEOSPLASH}"
-fi
-	set_audio alsa
-	#[ -e /storage/.config/asound.conf ] && mv /storage/.config/asound.conf /storage/.config/asound.confs
+    RND=$(get_ee_setting "ee_randombootvideo.enabled" == "1")
+    if [ "${RND}" == 1 ]; then
+        SPLASH=$(ls ${RANDOMVIDEO}/*.mp4 |sort -R |tail -1)
+        [[ -z "${SPLASH}" ]] && SPLASH="${VIDEOSPLASH}"
+    else
+        SPLASH="${VIDEOSPLASH}"
+    fi
+    set_audio alsa
     if [ ${SS_DEVICE} -eq 1 ]; then
         ${PLAYER} "${SPLASH}" > /dev/null 2>&1
     else
         ${PLAYER} -fs -autoexit ${SIZE} "${SPLASH}" > /dev/null 2>&1
     fi
-	touch "/storage/.config/emuelec/configs/novideo"
-	#[ -e /storage/.config/asound.confs ] && mv /storage/.config/asound.confs /storage/.config/asound.conf
+    touch "/storage/.config/emuelec/configs/novideo"
 fi
 
-# Wait for the time specified in ee_splash_delay setting in emuelec.conf
 SPLASHTIME=$(get_ee_setting ee_splash.delay)
 [ ! -z "${SPLASHTIME}" ] && sleep ${SPLASHTIME}

--- a/packages/sx05re/emuelec/bin/show_splash.sh
+++ b/packages/sx05re/emuelec/bin/show_splash.sh
@@ -102,112 +102,123 @@ elif [ "${ACTION_TYPE}" == "blank" ]; then
     SPLASH=${BLANKSPLASH}
 
 elif [ "${ACTION_TYPE}" == "gameloading" ]; then
-    # Standard fallback
+    # Default fallback for game loading splash image
     GAMELOADINGSPLASH="/storage/.config/splash/loading-game.png"
     if [[ "${MODE}" == *"x"* ]]; then
         GAMELOADINGSPLASH="/storage/.config/splash/loading-game-std.png"
     fi
 
-    ROMNAME=$(basename "${3%.*}")
-    SPLMAP="/emuelec/configs/bezels/arcademap.cfg"
-    SPLNAME=$(sed -n "/`echo ""${PLATFORM}"_"${ROMNAME}" = "`/p" "${SPLMAP}")
-    REALSPL="${SPLNAME#*\"}"
-    REALSPL="${REALSPL%\"*}"
+    # Custom splashscreen settings check
+    CUSTOM_GAME_VIDEO=$(get_ee_setting "ee_customsplashvideo")
+    CUSTOM_GAME_VIDEO_ENABLED=$(get_ee_setting "ee_customsplashvideo.enabled")
+    CUSTOM_GAME_IMAGE=$(get_ee_setting "ee_customsplashimage")
+    CUSTOM_GAME_IMAGE_ENABLED=$(get_ee_setting "ee_customsplashimage.enabled")
 
-    [ ! -z "${ROMNAME}" ] && SPLASH1=$(find ${SPLASHDIR}/${PLATFORM} -iname "${ROMNAME}*.png" -maxdepth 1 | sort -V | head -n 1)
-    [ ! -z "${ROMNAME}" ] && SPLASHVID1=$(find ${SPLASHDIR}/${PLATFORM} -iname "${ROMNAME}*.mp4" -maxdepth 1 | sort -V | head -n 1)
-    [ ! -z "${REALSPL}" ] && SPLASH2=$(find ${SPLASHDIR}/${PLATFORM} -iname "${REALSPL}*.png" -maxdepth 1 | sort -V | head -n 1)
-    [ ! -z "${REALSPL}" ] && SPLASHVID2=$(find ${SPLASHDIR}/${PLATFORM} -iname "${REALSPL}*.mp4" -maxdepth 1 | sort -V | head -n 1)
-
-    SPLASH3="${SPLASHDIR}/${PLATFORM}/launching.png"
-    SPLASHVID3="${SPLASHDIR}/${PLATFORM}/launching.mp4"
-    SPLASH4="${SPLASHDIR}/${PLATFORM}.png"
-    SPLASHVID4="${SPLASHDIR}/${PLATFORM}.mp4"
-    SPLASH5="${SPLASHDIR}/launching.png"
-    SPLASHVID5="${SPLASHDIR}/launching.mp4"
-
-    if [ -f "${SPLASHVID1}" ]; then
-        SPLASH="${SPLASHVID1}"
+    # Check if custom video or image is enabled and exists
+    if [[ "${CUSTOM_GAME_VIDEO_ENABLED}" == "1" ]] && [[ -f "${CUSTOM_GAME_VIDEO}" ]]; then
+        SPLASH="${CUSTOM_GAME_VIDEO}"
         VIDEO=1
-    elif [ -f "${SPLASH1}" ]; then
-        SPLASH="${SPLASH1}"
-        VIDEO=0
-    elif [ -f "${SPLASHVID2}" ]; then
-        SPLASH="${SPLASHVID2}"
-        VIDEO=1
-    elif [ -f "${SPLASH2}" ]; then
-        SPLASH="${SPLASH2}"
-        VIDEO=0
-    elif [ -f "${SPLASHVID3}" ]; then
-        SPLASH="${SPLASHVID3}"
-        VIDEO=1
-    elif [ -f "${SPLASH3}" ]; then
-        SPLASH="${SPLASH3}"
-        VIDEO=0
-    elif [ -f "${SPLASHVID4}" ]; then
-        SPLASH="${SPLASHVID4}"
-        VIDEO=1
-    elif [ -f "${SPLASH4}" ]; then
-        SPLASH="${SPLASH4}"
-        VIDEO=0
-    elif [ -f "${SPLASHVID5}" ]; then
-        SPLASH="${SPLASHVID5}"
-        VIDEO=1
-    elif [ -f "${SPLASH5}" ]; then
-        SPLASH="${SPLASH5}"
+    elif [[ "${CUSTOM_GAME_IMAGE_ENABLED}" == "1" ]] && [[ -f "${CUSTOM_GAME_IMAGE}" ]]; then
+        SPLASH="${CUSTOM_GAME_IMAGE}"
         VIDEO=0
     else
-        # Fallback auf konfigurierbare Optionen
-        GAMELOADINGVIDEO="/storage/roms/splash/${PLATFORM}/launching.mp4"
-        GLOBALGAMELOADINGVIDEO="/storage/roms/splash/launching.mp4"
-        GLOBALGAMELOADINGIMAGE="/storage/roms/splash/launching.png"
-        RANDOMSYSTEMVIDEO=$(get_random_video "/storage/roms/splash/${PLATFORM}")
-        RANDOMVIDEOFILE=$(get_random_video "/storage/roms/splash/video")
+        # ROM-based splashscreen check
+        ROMNAME=$(basename "${3%.*}")
+        SPLMAP="/emuelec/configs/bezels/arcademap.cfg"
+        SPLNAME=$(sed -n "/`echo ""${PLATFORM}"_"${ROMNAME}" = "`/p" "${SPLMAP}")
+        REALSPL="${SPLNAME#*\"}"
+        REALSPL="${REALSPL%\"*}"
 
-        CUSTOM_GAME_VIDEO=$(get_ee_setting "ee_customsplashvideo")
-        CUSTOM_GAME_VIDEO_ENABLED=$(get_ee_setting "ee_customsplashvideo.enabled")
-        CUSTOM_GAME_IMAGE=$(get_ee_setting "ee_customsplashimage")
-        CUSTOM_GAME_IMAGE_ENABLED=$(get_ee_setting "ee_customsplashimage.enabled")
+        # Search for ROM-specific splashscreens (image and video)
+        [ ! -z "${ROMNAME}" ] && SPLASH1=$(find ${SPLASHDIR}/${PLATFORM} -iname "${ROMNAME}*.png" -maxdepth 1 | sort -V | head -n 1)
+        [ ! -z "${ROMNAME}" ] && SPLASHVID1=$(find ${SPLASHDIR}/${PLATFORM} -iname "${ROMNAME}*.mp4" -maxdepth 1 | sort -V | head -n 1)
+        [ ! -z "${REALSPL}" ] && SPLASH2=$(find ${SPLASHDIR}/${PLATFORM} -iname "${REALSPL}*.png" -maxdepth 1 | sort -V | head -n 1)
+        [ ! -z "${REALSPL}" ] && SPLASHVID2=$(find ${SPLASHDIR}/${PLATFORM} -iname "${REALSPL}*.mp4" -maxdepth 1 | sort -V | head -n 1)
 
-        if [[ "${CUSTOM_GAME_VIDEO_ENABLED}" == "1" ]] && [[ -f "${CUSTOM_GAME_VIDEO}" ]]; then
-            SPLASH="${CUSTOM_GAME_VIDEO}"
+        # Default platform-wide splashscreens (image and video)
+        SPLASH3="${SPLASHDIR}/${PLATFORM}/launching.png"
+        SPLASHVID3="${SPLASHDIR}/${PLATFORM}/launching.mp4"
+        SPLASH4="${SPLASHDIR}/${PLATFORM}.png"
+        SPLASHVID4="${SPLASHDIR}/${PLATFORM}.mp4"
+        SPLASH5="${SPLASHDIR}/launching.png"
+        SPLASHVID5="${SPLASHDIR}/launching.mp4"
+
+        # Check for available splashscreens (video or image)
+        if [ -f "${SPLASHVID1}" ]; then
+            SPLASH="${SPLASHVID1}"
             VIDEO=1
-        elif [[ "${CUSTOM_GAME_IMAGE_ENABLED}" == "1" ]] && [[ -f "${CUSTOM_GAME_IMAGE}" ]]; then
-            SPLASH="${CUSTOM_GAME_IMAGE}"
+        elif [ -f "${SPLASH1}" ]; then
+            SPLASH="${SPLASH1}"
             VIDEO=0
-        elif [[ $(get_ee_setting "ee_systemloadingvideo.enabled") == "1" ]] && [[ -f "${GAMELOADINGVIDEO}" ]]; then
-            SPLASH="${GAMELOADINGVIDEO}"
+        elif [ -f "${SPLASHVID2}" ]; then
+            SPLASH="${SPLASHVID2}"
             VIDEO=1
-        elif [[ $(get_ee_setting "ee_randomsystemvideo.enabled") == "1" ]] && [[ -n "${RANDOMSYSTEMVIDEO}" ]]; then
-            SPLASH="${RANDOMSYSTEMVIDEO}"
-            VIDEO=1
-        elif [[ $(get_ee_setting "ee_randomloadingvideo.enabled") == "1" ]] && [[ -n "${RANDOMVIDEOFILE}" ]]; then
-            SPLASH="${RANDOMVIDEOFILE}"
-            VIDEO=1
-        elif [[ $(get_ee_setting "ee_standardloadingvideo.enabled") == "1" ]] && [[ -f "${GLOBALGAMELOADINGVIDEO}" ]]; then
-            SPLASH="${GLOBALGAMELOADINGVIDEO}"
-            VIDEO=1
-        elif [[ $(get_ee_setting "ee_randomimage.enabled") == "1" ]]; then
-            SPLASH=$(get_random_splash "${RANDOMSPLASHDIR}")
+        elif [ -f "${SPLASH2}" ]; then
+            SPLASH="${SPLASH2}"
             VIDEO=0
-        elif [[ $(get_ee_setting "ee_randomsystemimage.enabled") == "1" ]]; then
-            SPLASH=$(get_random_splash "${PLATFORMSPLASHDIR}")
-            VIDEO=0
-        elif [[ $(get_ee_setting "ee_systemsplashimage.enabled") == "1" ]]; then
-            SPLASH="${PLATFORMSPLASHDIR}/launching.png"
-            VIDEO=0
-        elif [[ $(get_ee_setting "ee_standardloadingimage.enabled") == "1" ]] && [[ -f "${GLOBALGAMELOADINGIMAGE}" ]]; then
-            SPLASH="${GLOBALGAMELOADINGIMAGE}"
-            VIDEO=0
-        elif [[ -f "${GLOBALGAMELOADINGVIDEO}" ]]; then
-            SPLASH="${GLOBALGAMELOADINGVIDEO}"
+        elif [ -f "${SPLASHVID3}" ]; then
+            SPLASH="${SPLASHVID3}"
             VIDEO=1
+        elif [ -f "${SPLASH3}" ]; then
+            SPLASH="${SPLASH3}"
+            VIDEO=0
+        elif [ -f "${SPLASHVID4}" ]; then
+            SPLASH="${SPLASHVID4}"
+            VIDEO=1
+        elif [ -f "${SPLASH4}" ]; then
+            SPLASH="${SPLASH4}"
+            VIDEO=0
+        elif [ -f "${SPLASHVID5}" ]; then
+            SPLASH="${SPLASHVID5}"
+            VIDEO=1
+        elif [ -f "${SPLASH5}" ]; then
+            SPLASH="${SPLASH5}"
+            VIDEO=0
         else
-            SPLASH="$GAMELOADINGSPLASH"
-            VIDEO=0
+            # Fallback to configurable splash options
+            GAMELOADINGVIDEO="/storage/roms/splash/${PLATFORM}/launching.mp4"
+            GLOBALGAMELOADINGVIDEO="/storage/roms/splash/launching.mp4"
+            GLOBALGAMELOADINGIMAGE="/storage/roms/splash/launching.png"
+            RANDOMSYSTEMVIDEO=$(get_random_video "/storage/roms/splash/${PLATFORM}")
+            RANDOMVIDEOFILE=$(get_random_video "/storage/roms/splash/video")
+
+            # System loading video fallback
+            if [[ $(get_ee_setting "ee_systemloadingvideo.enabled") == "1" ]] && [[ -f "${GAMELOADINGVIDEO}" ]]; then
+                SPLASH="${GAMELOADINGVIDEO}"
+                VIDEO=1
+            elif [[ $(get_ee_setting "ee_randomsystemvideo.enabled") == "1" ]] && [[ -n "${RANDOMSYSTEMVIDEO}" ]]; then
+                SPLASH="${RANDOMSYSTEMVIDEO}"
+                VIDEO=1
+            elif [[ $(get_ee_setting "ee_randomloadingvideo.enabled") == "1" ]] && [[ -n "${RANDOMVIDEOFILE}" ]]; then
+                SPLASH="${RANDOMVIDEOFILE}"
+                VIDEO=1
+            elif [[ $(get_ee_setting "ee_standardloadingvideo.enabled") == "1" ]] && [[ -f "${GLOBALGAMELOADINGVIDEO}" ]]; then
+                SPLASH="${GLOBALGAMELOADINGVIDEO}"
+                VIDEO=1
+            elif [[ $(get_ee_setting "ee_randomimage.enabled") == "1" ]]; then
+                SPLASH=$(get_random_splash "${RANDOMSPLASHDIR}")
+                VIDEO=0
+            elif [[ $(get_ee_setting "ee_randomsystemimage.enabled") == "1" ]]; then
+                SPLASH=$(get_random_splash "${PLATFORMSPLASHDIR}")
+                VIDEO=0
+            elif [[ $(get_ee_setting "ee_systemsplashimage.enabled") == "1" ]]; then
+                SPLASH="${PLATFORMSPLASHDIR}/launching.png"
+                VIDEO=0
+            elif [[ $(get_ee_setting "ee_standardloadingimage.enabled") == "1" ]] && [[ -f "${GLOBALGAMELOADINGIMAGE}" ]]; then
+                SPLASH="${GLOBALGAMELOADINGIMAGE}"
+                VIDEO=0
+            elif [[ -f "${GLOBALGAMELOADINGVIDEO}" ]]; then
+                SPLASH="${GLOBALGAMELOADINGVIDEO}"
+                VIDEO=1
+            else
+                SPLASH="$GAMELOADINGSPLASH"
+                VIDEO=0
+            fi
         fi
     fi
 fi
+
+
 
 
 # Odroid Go Advance still does not support splash screens

--- a/packages/sx05re/emuelec/config/emuelec/configs/emuelec.conf
+++ b/packages/sx05re/emuelec/config/emuelec/configs/emuelec.conf
@@ -14,6 +14,15 @@ global.maxperf=1
 ## Show a random splash mp4 video from /storage/roms/splash/video
 #ee_randombootvideo.enabled=0
 
+## Show a random splash image from /storage/roms/splash/random when loading a game
+ee_randomimage.enabled=0
+
+## Show a random splash systemimage from /storage/roms/splash/systempath when loading a game
+ee_randomsystemimage.enabled=0
+
+## Show launching.png from /storage/roms/splash/systempath when loading a game
+ee_systemsplashimage.enabled=0
+
 ## Set video mode
 ee_videomode=1080p60hz
 

--- a/packages/sx05re/emuelec/config/emuelec/configs/emuelec.conf
+++ b/packages/sx05re/emuelec/config/emuelec/configs/emuelec.conf
@@ -14,14 +14,38 @@ global.maxperf=1
 ## Show a random splash mp4 video from /storage/roms/splash/video
 #ee_randombootvideo.enabled=0
 
+## Show a random splash mp4 video from /storage/roms/splash/video
+ee_randombootvideo.enabled=0
+
+## Play launching.mp4 from /storage/roms/splash/ when loading a game
+ee_standardloadingvideo.enabled=0
+
+## Show a random splash mp4 video from /storage/roms/splash/video
+ee_randomloadingvideo.enabled=0
+
+## Play launching.mp4 from /storage/roms/splash/<system>/ when loading a game
+ee_systemloadingvideo.enabled=0
+
+## Play random .mp4 video from /storage/roms/splash/<system>/ when loading a game
+ee_randomsystemvideo.enabled=0
+
 ## Show a random splash image from /storage/roms/splash/random when loading a game
 ee_randomimage.enabled=0
 
-## Show a random splash systemimage from /storage/roms/splash/systempath when loading a game
+## Show a random splash systemimage from /storage/roms/splash/<system>/ when loading a game
 ee_randomsystemimage.enabled=0
 
-## Show launching.png from /storage/roms/splash/systempath when loading a game
+## Show launching.png from /storage/roms/splash/<system>/ when loading a game
 ee_systemsplashimage.enabled=0
+
+## Show launching.png from /storage/roms/splash/ when loading a game
+ee_standardloadingimage.enabled=1
+
+# Enable exit splash video (using /storage/roms/splash/exitvideo.mp4)
+ee_exitvideo.enabled=0
+
+# Enable exit splash image (using /storage/roms/splash/exitsplash.png)
+ee_exitsplashimage.enabled=1
 
 ## Set video mode
 ee_videomode=1080p60hz

--- a/packages/sx05re/emuelec/config/emuelec/configs/emuelec.conf
+++ b/packages/sx05re/emuelec/config/emuelec/configs/emuelec.conf
@@ -11,8 +11,16 @@ global.maxperf=1
 ## Always show boot video
 #ee_bootvideo.enabled=0
 
+## Show a custom splash image
+ee_customsplashimage.enabled=0
+ee_customsplashimage=
+
+## Show a custom splash video
+ee_customsplashvideo.enabled=0
+ee_customsplashvideo=
+
 ## Show a random splash mp4 video from /storage/roms/splash/video
-#ee_randombootvideo.enabled=0
+ee_randombootvideo.enabled=0
 
 ## Show a random splash mp4 video from /storage/roms/splash/video
 ee_randombootvideo.enabled=0
@@ -36,15 +44,23 @@ ee_randomimage.enabled=0
 ee_randomsystemimage.enabled=0
 
 ## Show launching.png from /storage/roms/splash/<system>/ when loading a game
-ee_systemsplashimage.enabled=0
+ee_systemsplashimage.enabled=1
 
 ## Show launching.png from /storage/roms/splash/ when loading a game
-ee_standardloadingimage.enabled=1
+ee_standardloadingimage.enabled=0
 
-# Enable exit splash video (using /storage/roms/splash/exitvideo.mp4)
+## Enable custom exit splash video
+ee_customexitsplashvideo.enabled=0
+ee_customexitsplashvideo=
+
+## Enable custom exit splash image
+ee_customexitsplashimage.enabled=0
+ee_customexitsplashimage=
+
+## Enable exit splash video (using /storage/roms/splash/exitvideo.mp4)
 ee_exitvideo.enabled=0
 
-# Enable exit splash image (using /storage/roms/splash/exitsplash.png)
+## Enable exit splash image (using /storage/roms/splash/exitsplash.png)
 ee_exitsplashimage.enabled=1
 
 ## Set video mode


### PR DESCRIPTION
In combination to the new entries in GuiMenu.cpp in emuelec-emulationstation (to show splash configuration in the emulationstation menu), the updated show_splash.sh now works with the following new entries in emuelec.conf:

\## Show a custom splash image
ee_customsplashimage.enabled=0
ee_customsplashimage=

\## Show a custom splash video
ee_customsplashvideo.enabled=0
ee_customsplashvideo=

\## Play launching.mp4 from /storage/roms/splash/ when loading a game
ee_standardloadingvideo.enabled=0

\## Show a random splash mp4 video from /storage/roms/splash/video
ee_randomloadingvideo.enabled=0

\## Play launching.mp4 from /storage/roms/splash/<system>/ when loading a game
ee_systemloadingvideo.enabled=0

\## Play random .mp4 video from /storage/roms/splash/<system>/ when loading a game
ee_randomsystemvideo.enabled=0

\## Show a random splash image from /storage/roms/splash/random when loading a game
ee_randomimage.enabled=0

\## Show a random splash systemimage from /storage/roms/splash/<system>/ when loading a game
ee_randomsystemimage.enabled=0

\## Show launching.png from /storage/roms/splash/<system>/ when loading a game
ee_systemsplashimage.enabled=0

\## Show launching.png from /storage/roms/splash/ when loading a game
ee_standardloadingimage.enabled=1

\## Enable custom exit splash video
ee_customexitsplashvideo.enabled=0
ee_customexitsplashvideo=

\## Enable custom exit splash image
ee_customexitsplashimage.enabled=0
ee_customexitsplashimage=

\## Enable exit splash video (using /storage/roms/splash/exitvideo.mp4)
ee_exitvideo.enabled=0

\## Enable exit splash image (using /storage/roms/splash/exitsplash.png)
ee_exitsplashimage.enabled=1