### PR TITLE
Add new variable ee_menuscroll into emuelec.conf for custom menu scroll sound 

### DIFF
--- a/packages/sx05re/emuelec/config/emuelec/configs/emuelec.conf
+++ b/packages/sx05re/emuelec/config/emuelec/configs/emuelec.conf
@@ -106,6 +106,9 @@ audio.device=auto
 audio.volume=100
 ## Enable or disable system sounds in ES (0,1)
 audio.bgmusic=1
+## Custom menu scroll sound (.ogg-file)
+ee_menuscrollsound=
+
 
 # -------------- D - Controllers ----------------- #
 # Enable support for standard bluetooth controllers


### PR DESCRIPTION
In order to work with the new custom file browser option in the emulationstation-menu
 (PR is https://github.com/EmuELEC/emuelec-emulationstation/pull/123),
there is a new variable inside emuelec.conf where the path to the file is being stored:

\## Custom menu scroll sound (.ogg-file)
ee_menuscrollsound=