### PR TITLE
EmuELEC - Adding arguments to emustation and retroarch services.

### DIFF
--- a/packages/sx05re/emuelec-emulationstation/system.d/emustation.service
+++ b/packages/sx05re/emuelec-emulationstation/system.d/emustation.service
@@ -7,7 +7,7 @@ Environment=HOME=/storage
 EnvironmentFile=/storage/.config/emulationstation/scripts/es_env.sh
 ExecStartPre=emustation-config
 ExecStartPre=/usr/bin/killes.sh
-ExecStart=/bin/bash 'emulationstation $(cat /emuelec/configs/ES_ARGS)'
+ExecStart=/bin/bash -c 'emulationstation $(cat /emuelec/configs/ES_ARGS)'
 KillMode=process
 TimeoutStopSec=3
 Restart=always

--- a/packages/sx05re/emuelec-emulationstation/system.d/emustation.service
+++ b/packages/sx05re/emuelec-emulationstation/system.d/emustation.service
@@ -7,7 +7,7 @@ Environment=HOME=/storage
 EnvironmentFile=/storage/.config/emulationstation/scripts/es_env.sh
 ExecStartPre=emustation-config
 ExecStartPre=/usr/bin/killes.sh
-ExecStart=emulationstation $(cat /emuelec/configs/ES_ARGS)
+ExecStart=/bin/bash 'emulationstation $(cat /emuelec/configs/ES_ARGS)'
 KillMode=process
 TimeoutStopSec=3
 Restart=always

--- a/packages/sx05re/emuelec-emulationstation/system.d/emustation.service
+++ b/packages/sx05re/emuelec-emulationstation/system.d/emustation.service
@@ -7,7 +7,7 @@ Environment=HOME=/storage
 EnvironmentFile=/storage/.config/emulationstation/scripts/es_env.sh
 ExecStartPre=emustation-config
 ExecStartPre=/usr/bin/killes.sh
-ExecStart=emulationstation
+ExecStart=emulationstation $(cat /emuelec/configs/ES_ARGS)
 KillMode=process
 TimeoutStopSec=3
 Restart=always

--- a/packages/sx05re/emuelec/bin/emuelecRunEmu.sh
+++ b/packages/sx05re/emuelec/bin/emuelecRunEmu.sh
@@ -360,7 +360,7 @@ else
     ROMNAME_SHADER=${ROMNAME}
 fi
 
-RUNTHIS='${RABIN} ${VERBOSE} -L /tmp/cores/${EMU}.so --config ${RACONF} "${ROMNAME}"'
+RUNTHIS='${RABIN} ${VERBOSE} $(cat /emuelec/configs/RA_ARGS) -L /tmp/cores/${EMU}.so --config ${RACONF} "${ROMNAME}"'
 CONTROLLERCONFIG="${arguments#*--controllers=*}"
 
 if [[ "${arguments}" == *"-state_slot"* ]]; then

--- a/packages/sx05re/libretro/retroarch/system.d/retroarch.service
+++ b/packages/sx05re/libretro/retroarch/system.d/retroarch.service
@@ -8,7 +8,7 @@ Environment=SDL_MOUSE_RELATIVE=0
 Environment=FB_MULTI_BUFFER=2
 Environment=HOME=/storage
 ExecStartPre=/usr/bin/emustation-config retroarch
-ExecStart=/bin/bash '/usr/bin/retroarch $(cat /emuelec/configs/RA_ARGS)'
+ExecStart=/bin/bash -c '/usr/bin/retroarch $(cat /emuelec/configs/RA_ARGS)'
 KillMode=process
 TimeoutStopSec=3
 Restart=on-failure

--- a/packages/sx05re/libretro/retroarch/system.d/retroarch.service
+++ b/packages/sx05re/libretro/retroarch/system.d/retroarch.service
@@ -8,7 +8,7 @@ Environment=SDL_MOUSE_RELATIVE=0
 Environment=FB_MULTI_BUFFER=2
 Environment=HOME=/storage
 ExecStartPre=/usr/bin/emustation-config retroarch
-ExecStart=/usr/bin/retroarch $(cat /emuelec/configs/RA_ARGS)
+ExecStart=/bin/bash '/usr/bin/retroarch $(cat /emuelec/configs/RA_ARGS)'
 KillMode=process
 TimeoutStopSec=3
 Restart=on-failure

--- a/packages/sx05re/libretro/retroarch/system.d/retroarch.service
+++ b/packages/sx05re/libretro/retroarch/system.d/retroarch.service
@@ -8,7 +8,7 @@ Environment=SDL_MOUSE_RELATIVE=0
 Environment=FB_MULTI_BUFFER=2
 Environment=HOME=/storage
 ExecStartPre=/usr/bin/emustation-config retroarch
-ExecStart=/usr/bin/retroarch
+ExecStart=/usr/bin/retroarch $(cat /emuelec/configs/RA_ARGS)
 KillMode=process
 TimeoutStopSec=3
 Restart=on-failure


### PR DESCRIPTION
EmuELEC - Adding arguments to emustation and retroarch services.

Enables the user to add arguments to the emulationstation and retroarch services. This is in case the user want to supply arguments after the call to execute those services has started.

For instance if I wanted to screen rotate ES I could just do:
echo "--screenrotate 1" > /emuelec/configs/ES_ARGS

Then every time the service is launched the supplied arguments will appear after the call to emulationstation and retroarch services respectfully.

For Retroarch it's:
echo "--someargument 1" > /emuelec/configs/RA_ARGS
