### PR TITLE
Automatic shutdown function after user inactivity

### DIFF
--- a/packages/sx05re/emuelec/bin/emuelecRunEmu.sh
+++ b/packages/sx05re/emuelec/bin/emuelecRunEmu.sh
@@ -602,5 +602,6 @@ if [[ "${ret_error}" != "0" ]]; then
 else
     echo "exit 0" >> ${EMUELECLOG}
     blank_buffer
+	echo "return_from_game" > /tmp/es_return_from_game
     exit 0
 fi

--- a/packages/sx05re/emuelec/config/emuelec/configs/emuelec.conf
+++ b/packages/sx05re/emuelec/config/emuelec/configs/emuelec.conf
@@ -8,6 +8,9 @@ ee_bluetooth.enabled=1
 ## Use maxperf, enable max settings for GPU and performance governer, this setting can be set globally, per platform or per game on the ES menu
 global.maxperf=1
 
+## Auto shutdown timer (in minutes, 0 is OFF)
+ee_auto_shutdown_timeout=0
+
 ## Always show boot video
 #ee_bootvideo.enabled=0
 


### PR DESCRIPTION
Both (updated) files emuelec.conf and emuelecRunEmu.sh are needed in combination with the automatic-shutdown-function PR 
https://github.com/EmuELEC/emuelec-emulationstation/pull/129

1. Added the variable "ee_auto_shutdown_timeout" in emuelec.conf that sets the amount of minutes until shutdown when the user is inactive.

2. Added a command in in "emuelecRunEmu.sh"  that creates a temporary check-file when exiting emulators and returning back to Emulationstation. Said file is used to reset the inactivity timer again to zero.