### PR TITLE
Emuelec - dev - system platforms update - odyssey and sgfx renaming.

### DIFF
--- a/packages/sx05re/emuelec-emulationstation/config/es_systems.cfg
+++ b/packages/sx05re/emuelec-emulationstation/config/es_systems.cfg
@@ -812,7 +812,7 @@ This file will be replaced on any new update of EmuELEC-->
 		<manufacturer>Magnavox - Philips</manufacturer>
 		<release>1979</release>
 		<hardware>console</hardware>
-		<path>/storage/roms/odyssey</path>
+		<path>/storage/roms/odyssey2</path>
 		<extension>.bin .BIN .zip .ZIP .7z .7Z</extension>
 		<command>emuelecRunEmu.sh %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers="%CONTROLLERSCONFIG%"</command>
 		<platform>odyssey2</platform>
@@ -957,7 +957,7 @@ This file will be replaced on any new update of EmuELEC-->
 		<manufacturer>NEC</manufacturer>
 		<release>1989</release>
 		<hardware>console</hardware>
-		<path>/storage/roms/sgfx</path>
+		<path>/storage/roms/supergrafx</path>
 		<extension>.pce .PCE .sgx .SGX .cue .CUE .ccd .CCD .chd .CHD .zip .ZIP .7z .7Z</extension>
 		<command>emuelecRunEmu.sh %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers="%CONTROLLERSCONFIG%"</command>
 		<platform>supergrafx</platform>

--- a/packages/sx05re/emuelec/tmpfiles.d/emuelec-dirs.conf
+++ b/packages/sx05re/emuelec/tmpfiles.d/emuelec-dirs.conf
@@ -91,7 +91,7 @@ d    /storage/roms/nes                  0777 root root - -
 d    /storage/roms/nesh                 0777 root root - -
 d    /storage/roms/ngp                  0777 root root - -
 d    /storage/roms/ngpc                 0777 root root - -
-d    /storage/roms/odyssey              0777 root root - -
+d    /storage/roms/odyssey2             0777 root root - -
 d    /storage/roms/openbor              0777 root root - -
 d    /storage/roms/pc                   0777 root root - -
 d    /storage/roms/pc98                 0777 root root - -
@@ -150,7 +150,7 @@ d    /storage/roms/sega32x              0777 root root - -
 d    /storage/roms/segacd               0777 root root - -
 d    /storage/roms/sfc                  0777 root root - -
 d    /storage/roms/sg-1000              0777 root root - -
-d    /storage/roms/sgfx                 0777 root root - -
+d    /storage/roms/supergrafx           0777 root root - -
 d    /storage/roms/snes                 0777 root root - -
 d    /storage/roms/snesh                0777 root root - -
 d    /storage/roms/snesmsu1             0777 root root - -


### PR DESCRIPTION
Emuelec - dev - system platforms update - odyssey and sgfx renaming.

function rename_rom_system removed.

Clean commit from:
https://github.com/EmuELEC/EmuELEC/pull/1503