### PR TITLE
Updated show_splash.sh and emuelec.conf for fullscreen splash screen/video use

### DIFF
--- a/packages/sx05re/emuelec/bin/show_splash.sh
+++ b/packages/sx05re/emuelec/bin/show_splash.sh
@@ -13,228 +13,173 @@
 
 ACTION_TYPE="${1}"
 PLATFORM="${2}"
->/emuelec/logs/logx.txt
-echo ${PLATFORM} >> /emuelec/logs/logx.txt
 
 GAMELOADINGSPLASH="/storage/.config/splash/loading-game.png"
 BLANKSPLASH="/storage/.config/splash/blank.png"
 DEFAULTSPLASH="/storage/.config/splash/splash-1080.png"
 VIDEOSPLASH="/usr/config/splash/emuelec_intro_1080p.mp4"
 RANDOMVIDEO="/storage/roms/splash/introvideos"
-DURATION="5"
 
-if [ -f "/storage/roms/splash/intro.mp4" ]; then
-    VIDEOSPLASH="/storage/roms/splash/intro.mp4"
-fi
+[ -f "/storage/roms/splash/intro.mp4" ] && VIDEOSPLASH="/storage/roms/splash/intro.mp4"
 
-if [ -f "/storage/.config/splash/loading-game.mp4" ]; then
-    GAMELOADINGSPLASH="/storage/.config/splash/loading-game.mp4"
-fi
-
-# Convert the platform name to lowercase
 PLATFORM=${PLATFORM,,}
-PLAYER="ffplay"
-echo ${PLATFORM} >> /emuelec/logs/logx.txt
+PLAYER_VID="ffplay"
+PLAYER_IMG="mpv"
+
+have_mpv=0; command -v mpv >/dev/null 2>&1 && have_mpv=1
 
 case ${PLATFORM} in
- "arcade"|"fba"|"fbn"|"neogeo"|"mame"|cps*)
-   PLATFORM="arcade"
-  ;;
- "retropie"|"setup")
-   # fbterm does not like the splash screen 
-   exit 0
-  ;;
+  arcade|fba|fbn|neogeo|mame|cps*) PLATFORM="arcade" ;;
+  retropie|setup) exit 0 ;;
 esac
 
-MODE=`get_resolution`
-
+MODE="$(get_resolution)"
 SPLASHDIR="/storage/roms/splash"
-  
-if [ "${ACTION_TYPE}" == "intro" ] || [ "${ACTION_TYPE}" == "exit" ]; then
-    SPLASH=${DEFAULTSPLASH}
-    if [[ "${MODE}" == *"x"* ]]; then
-        SPLASH="/storage/.config/splash/splash-std.png"
+
+if [ "${ACTION_TYPE}" = "intro" ] || [ "${ACTION_TYPE}" = "exit" ]; then
+  SPLASH="${DEFAULTSPLASH}"
+  [[ "${MODE}" == *"x"* ]] && SPLASH="/storage/.config/splash/splash-std.png"
+
+  if [ "${ACTION_TYPE}" = "exit" ]; then
+    CUSTOM_EXIT_VIDEO_ENABLED="$(get_ee_setting ee_customexitsplashvideo.enabled)"
+    CUSTOM_EXIT_VIDEO="$(get_ee_setting ee_customexitsplashvideo)"
+    CUSTOM_EXIT_IMAGE_ENABLED="$(get_ee_setting ee_customexitsplashimage.enabled)"
+    CUSTOM_EXIT_IMAGE="$(get_ee_setting ee_customexitsplashimage)"
+    EXIT_VIDEO_ENABLED="$(get_ee_setting ee_exitvideo.enabled)"
+    EXIT_IMAGE_ENABLED="$(get_ee_setting ee_exitsplashimage.enabled)"
+
+    if [ "${CUSTOM_EXIT_VIDEO_ENABLED}" = "1" ] && [ -n "${CUSTOM_EXIT_VIDEO}" ] && [ -f "${CUSTOM_EXIT_VIDEO}" ]; then
+      SPLASH="${CUSTOM_EXIT_VIDEO}"
+    elif [ "${CUSTOM_EXIT_IMAGE_ENABLED}" = "1" ] && [ -n "${CUSTOM_EXIT_IMAGE}" ] && [ -f "${CUSTOM_EXIT_IMAGE}" ]; then
+      SPLASH="${CUSTOM_EXIT_IMAGE}"
+    elif [ "${EXIT_VIDEO_ENABLED}" = "1" ] && [ -f "/storage/roms/splash/exitvideo.mp4" ]; then
+      SPLASH="/storage/roms/splash/exitvideo.mp4"
+    elif [ "${EXIT_IMAGE_ENABLED}" = "1" ] && [ -f "/storage/roms/splash/exitsplash.png" ]; then
+      SPLASH="/storage/roms/splash/exitsplash.png"
     fi
+  fi
 
-    # Extended section for exit action: integrate additional settings from emuelec.conf
-    if [ "${ACTION_TYPE}" == "exit" ]; then
-        CUSTOM_EXIT_VIDEO_ENABLED=$(get_ee_setting ee_customexitsplashvideo.enabled)
-        CUSTOM_EXIT_VIDEO=$(get_ee_setting ee_customexitsplashvideo)
-        CUSTOM_EXIT_IMAGE_ENABLED=$(get_ee_setting ee_customexitsplashimage.enabled)
-        CUSTOM_EXIT_IMAGE=$(get_ee_setting ee_customexitsplashimage)
-        EXIT_VIDEO_ENABLED=$(get_ee_setting ee_exitvideo.enabled)
-        EXIT_IMAGE_ENABLED=$(get_ee_setting ee_exitsplashimage.enabled)
-        
-        if [ "${CUSTOM_EXIT_VIDEO_ENABLED}" == "1" ] && [ -n "${CUSTOM_EXIT_VIDEO}" ] && [ -f "${CUSTOM_EXIT_VIDEO}" ]; then
-            SPLASH="${CUSTOM_EXIT_VIDEO}"
-        elif [ "${CUSTOM_EXIT_IMAGE_ENABLED}" == "1" ] && [ -n "${CUSTOM_EXIT_IMAGE}" ] && [ -f "${CUSTOM_EXIT_IMAGE}" ]; then
-            SPLASH="${CUSTOM_EXIT_IMAGE}"
-        elif [ "${EXIT_VIDEO_ENABLED}" == "1" ] && [ -f "/storage/roms/splash/exitvideo.mp4" ]; then
-            SPLASH="/storage/roms/splash/exitvideo.mp4"
-        elif [ "${EXIT_IMAGE_ENABLED}" == "1" ] && [ -f "/storage/roms/splash/exitsplash.png" ]; then
-            SPLASH="/storage/roms/splash/exitsplash.png"
-        fi
-    fi
+elif [ "${ACTION_TYPE}" = "blank" ]; then
+  SPLASH="${BLANKSPLASH}"
 
-elif [ "${ACTION_TYPE}" == "blank" ]; then
-    SPLASH=${BLANKSPLASH}
-elif [ "${ACTION_TYPE}" == "gameloading" ]; then
-    if [[ "${MODE}" == *"x"* ]]; then
-        GAMELOADINGSPLASH="/storage/.config/splash/loading-game-std.png"
+elif [ "${ACTION_TYPE}" = "gameloading" ]; then
+  [[ "${MODE}" == *"x"* ]] && GAMELOADINGSPLASH="/storage/.config/splash/loading-game-std.png"
 
-        if [ -f "/storage/.config/splash/loading-game-std.mp4" ]; then
-            GAMELOADINGSPLASH="/storage/.config/splash/loading-game-std.mp4"
-        fi
+  CUSTOM_SPLASH_IMAGE_ENABLED="$(get_ee_setting ee_customsplashimage.enabled)"
+  CUSTOM_SPLASH_IMAGE="$(get_ee_setting ee_customsplashimage)"
+  CUSTOM_SPLASH_VIDEO_ENABLED="$(get_ee_setting ee_customsplashvideo.enabled)"
+  CUSTOM_SPLASH_VIDEO="$(get_ee_setting ee_customsplashvideo)"
+  STANDARD_LOADING_VIDEO_ENABLED="$(get_ee_setting ee_standardloadingvideo.enabled)"
+  RANDOM_LOADING_VIDEO_ENABLED="$(get_ee_setting ee_randomloadingvideo.enabled)"
+  SYSTEM_LOADING_VIDEO_ENABLED="$(get_ee_setting ee_systemloadingvideo.enabled)"
+  RANDOM_SYSTEM_VIDEO_ENABLED="$(get_ee_setting ee_randomsystemvideo.enabled)"
+  RANDOM_IMAGE_ENABLED="$(get_ee_setting ee_randomimage.enabled)"
+  RANDOM_SYSTEM_IMAGE_ENABLED="$(get_ee_setting ee_randomsystemimage.enabled)"
+  SYSTEM_SPLASH_IMAGE_ENABLED="$(get_ee_setting ee_systemsplashimage.enabled)"
+  STANDARD_LOADING_IMAGE_ENABLED="$(get_ee_setting ee_standardloadingimage.enabled)"
 
-    fi
+  if [ "${CUSTOM_SPLASH_IMAGE_ENABLED}" = "1" ] && [ -n "${CUSTOM_SPLASH_IMAGE}" ] && [ -f "${CUSTOM_SPLASH_IMAGE}" ]; then
+    SPLASH="${CUSTOM_SPLASH_IMAGE}"
+  elif [ "${CUSTOM_SPLASH_VIDEO_ENABLED}" = "1" ] && [ -n "${CUSTOM_SPLASH_VIDEO}" ] && [ -f "${CUSTOM_SPLASH_VIDEO}" ]; then
+    SPLASH="${CUSTOM_SPLASH_VIDEO}"
+  elif [ "${STANDARD_LOADING_VIDEO_ENABLED}" = "1" ] && [ -f "/storage/roms/splash/launching.mp4" ]; then
+    SPLASH="/storage/roms/splash/launching.mp4"
+  elif [ "${RANDOM_LOADING_VIDEO_ENABLED}" = "1" ]; then
+    SPLASH="$(ls /storage/roms/splash/video/*.mp4 2>/dev/null | sort -R | head -n 1)"
+  elif [ "${SYSTEM_LOADING_VIDEO_ENABLED}" = "1" ] && [ -f "${SPLASHDIR}/${PLATFORM}/launching.mp4" ]; then
+    SPLASH="${SPLASHDIR}/${PLATFORM}/launching.mp4"
+  elif [ "${RANDOM_SYSTEM_VIDEO_ENABLED}" = "1" ] && [ -d "${SPLASHDIR}/${PLATFORM}" ]; then
+    SPLASH="$(ls ${SPLASHDIR}/${PLATFORM}/*.mp4 2>/dev/null | sort -R | head -n 1)"
+  elif [ "${RANDOM_IMAGE_ENABLED}" = "1" ]; then
+    SPLASH="$(ls /storage/roms/splash/random/*.{png,jpg,jpeg} 2>/dev/null | sort -R | head -n 1)"
+  elif [ "${RANDOM_SYSTEM_IMAGE_ENABLED}" = "1" ] && [ -d "${SPLASHDIR}/${PLATFORM}" ]; then
+    SPLASH="$(ls ${SPLASHDIR}/${PLATFORM}/*.{png,jpg,jpeg} 2>/dev/null | sort -R | head -n 1)"
+  elif [ "${SYSTEM_SPLASH_IMAGE_ENABLED}" = "1" ] && [ -f "${SPLASHDIR}/${PLATFORM}/launching.png" ]; then
+    SPLASH="${SPLASHDIR}/${PLATFORM}/launching.png"
+  elif [ "${STANDARD_LOADING_IMAGE_ENABLED}" = "1" ] && [ -f "/storage/roms/splash/launching.png" ]; then
+    SPLASH="/storage/roms/splash/launching.png"
+  fi
 
-    # Extended gameloading settings from emuelec.conf:
-    CUSTOM_SPLASH_IMAGE_ENABLED=$(get_ee_setting ee_customsplashimage.enabled)
-    CUSTOM_SPLASH_IMAGE=$(get_ee_setting ee_customsplashimage)
-    CUSTOM_SPLASH_VIDEO_ENABLED=$(get_ee_setting ee_customsplashvideo.enabled)
-    CUSTOM_SPLASH_VIDEO=$(get_ee_setting ee_customsplashvideo)
-    STANDARD_LOADING_VIDEO_ENABLED=$(get_ee_setting ee_standardloadingvideo.enabled)
-    RANDOM_LOADING_VIDEO_ENABLED=$(get_ee_setting ee_randomloadingvideo.enabled)
-    SYSTEM_LOADING_VIDEO_ENABLED=$(get_ee_setting ee_systemloadingvideo.enabled)
-    RANDOM_SYSTEM_VIDEO_ENABLED=$(get_ee_setting ee_randomsystemvideo.enabled)
-    RANDOM_IMAGE_ENABLED=$(get_ee_setting ee_randomimage.enabled)
-    RANDOM_SYSTEM_IMAGE_ENABLED=$(get_ee_setting ee_randomsystemimage.enabled)
-    SYSTEM_SPLASH_IMAGE_ENABLED=$(get_ee_setting ee_systemsplashimage.enabled)
-    STANDARD_LOADING_IMAGE_ENABLED=$(get_ee_setting ee_standardloadingimage.enabled)
-
-    if [ "${CUSTOM_SPLASH_IMAGE_ENABLED}" == "1" ] && [ -n "${CUSTOM_SPLASH_IMAGE}" ] && [ -f "${CUSTOM_SPLASH_IMAGE}" ]; then
-        SPLASH="${CUSTOM_SPLASH_IMAGE}"
-    elif [ "${CUSTOM_SPLASH_VIDEO_ENABLED}" == "1" ] && [ -n "${CUSTOM_SPLASH_VIDEO}" ] && [ -f "${CUSTOM_SPLASH_VIDEO}" ]; then
-        SPLASH="${CUSTOM_SPLASH_VIDEO}"
-    elif [ "${STANDARD_LOADING_VIDEO_ENABLED}" == "1" ] && [ -f "/storage/roms/splash/launching.mp4" ]; then
-        SPLASH="/storage/roms/splash/launching.mp4"
-    elif [ "${RANDOM_LOADING_VIDEO_ENABLED}" == "1" ]; then
-        SPLASH=$(ls /storage/roms/splash/video/*.mp4 2>/dev/null | sort -R | head -n 1)
-    elif [ "${SYSTEM_LOADING_VIDEO_ENABLED}" == "1" ] && [ -d "${SPLASHDIR}/${PLATFORM}" ] && [ -f "${SPLASHDIR}/${PLATFORM}/launching.mp4" ]; then
-        SPLASH="${SPLASHDIR}/${PLATFORM}/launching.mp4"
-    elif [ "${RANDOM_SYSTEM_VIDEO_ENABLED}" == "1" ] && [ -d "${SPLASHDIR}/${PLATFORM}" ]; then
-        SPLASH=$(ls ${SPLASHDIR}/${PLATFORM}/*.mp4 2>/dev/null | sort -R | head -n 1)
-    elif [ "${RANDOM_IMAGE_ENABLED}" == "1" ]; then
-        SPLASH=$(ls /storage/roms/splash/random/*.{png,jpg,jpeg} 2>/dev/null | sort -R | head -n 1)
-    elif [ "${RANDOM_SYSTEM_IMAGE_ENABLED}" == "1" ] && [ -d "${SPLASHDIR}/${PLATFORM}" ]; then
-        SPLASH=$(ls ${SPLASHDIR}/${PLATFORM}/*.{png,jpg,jpeg} 2>/dev/null | sort -R | head -n 1)
-    elif [ "${SYSTEM_SPLASH_IMAGE_ENABLED}" == "1" ] && [ -f "${SPLASHDIR}/${PLATFORM}/launching.png" ]; then
-        SPLASH="${SPLASHDIR}/${PLATFORM}/launching.png"
-    elif [ "${STANDARD_LOADING_IMAGE_ENABLED}" == "1" ] && [ -f "/storage/roms/splash/launching.png" ]; then
-        SPLASH="/storage/roms/splash/launching.png"
-    fi
-
-    # If no valid file was selected using custom settings, fallback to the default matching logic:
-    if [ -z "${SPLASH}" ]; then
-        ROMNAME=$(basename "${3%.*}")
-        SPLMAP="/emuelec/configs/bezels/arcademap.cfg"
-        SPLNAME=$(sed -n "/$(echo "${PLATFORM}_${ROMNAME} = ")/p" "${SPLMAP}")
-        REALSPL="${SPLNAME#*\"}"
-        REALSPL="${REALSPL%\"*}"
-        [ ! -z "${ROMNAME}" ] && SPLASH1=$(find ${SPLASHDIR}/${PLATFORM} -iname "${ROMNAME}*.png" -maxdepth 1 | sort -V | head -n 1)
-        [ ! -z "${ROMNAME}" ] && SPLASHVID1=$(find ${SPLASHDIR}/${PLATFORM} -iname "${ROMNAME}*.mp4" -maxdepth 1 | sort -V | head -n 1)
-        [ ! -z "${REALSPL}" ] && SPLASH2=$(find ${SPLASHDIR}/${PLATFORM} -iname "${REALSPL}*.png" -maxdepth 1 | sort -V | head -n 1)
-        [ ! -z "${REALSPL}" ] && SPLASHVID2=$(find ${SPLASHDIR}/${PLATFORM} -iname "${REALSPL}*.mp4" -maxdepth 1 | sort -V | head -n 1)
-
-        SPLASH3="${SPLASHDIR}/${PLATFORM}/launching.png"
-        SPLASHVID3="${SPLASHDIR}/${PLATFORM}/launching.mp4"
-
-        SPLASH4="${SPLASHDIR}/${PLATFORM}.png"
-        SPLASHVID4="${SPLASHDIR}/${PLATFORM}.mp4"
-
-        SPLASH5="${SPLASHDIR}/launching.png"
-        SPLASHVID5="${SPLASHDIR}/launching.mp4"
-        
-        if [ -f "${SPLASHVID1}" ]; then
-            SPLASH="${SPLASHVID1}"
-        elif [ -f "${SPLASH1}" ]; then
-            SPLASH="${SPLASH1}"
-        elif [ -f "${SPLASHVID2}" ]; then
-            SPLASH="${SPLASHVID2}"
-        elif [ -f "${SPLASH2}" ]; then
-            SPLASH="${SPLASH2}"
-        elif [ -f "${SPLASHVID3}" ]; then
-            SPLASH="${SPLASHVID3}"
-        elif [ -f "${SPLASH3}" ]; then
-            SPLASH="${SPLASH3}"
-        elif [ -f "${SPLASHVID4}" ]; then
-            SPLASH="${SPLASHVID4}"
-        elif [ -f "${SPLASH4}" ]; then
-            SPLASH="${SPLASH4}"
-        elif [ -f "${SPLASHVID5}" ]; then
-            SPLASH="${SPLASHVID5}"
-        elif [ -f "${SPLASH5}" ]; then
-            SPLASH="${SPLASH5}"
-        else
-            SPLASH="${GAMELOADINGSPLASH}"
-        fi
-    fi
+  [ -z "${SPLASH}" ] && SPLASH="${GAMELOADINGSPLASH}"
 fi
 
-# Odroid Go Advance and GameForce do not support splash screens yet
+# OGA/GameForce -> mpv
 SS_DEVICE=0
 if [[ "${EE_DEVICE}" == "OdroidGoAdvance" ]] || [[ "${EE_DEVICE}" == "GameForce" ]]; then
-    SS_DEVICE=1
-    clear > /dev/console
-    echo "Loading ..." > /dev/console
-    PLAYER="mpv"
+  SS_DEVICE=1
+  clear > /dev/console
+  echo "Loading ..." > /dev/console
+  PLAYER_VID="mpv"
+  PLAYER_IMG="mpv"
+  have_mpv=1
 fi
 
 declare -a RES=( ${MODE} )
-SIZE=" -x ${RES[0]} -y ${RES[1]}"
 SCALE="${RES[0]}:${RES[1]}"
-EXTENSION="${SPLASH##*.}"
+FILTER_FILL="scale=${SCALE}:force_original_aspect_ratio=increase,crop=${RES[0]}:${RES[1]},setsar=1"
+MPV_VF="${FILTER_FILL}"
 
-[[ "${ACTION_TYPE}" != "intro" ]] && VIDEO=0 || VIDEO=$(get_ee_setting ee_bootvideo.enabled)
+[[ "${ACTION_TYPE}" != "intro" ]] && VIDEO=0 || VIDEO="$(get_ee_setting ee_bootvideo.enabled)"
+
+is_video() { case "${1,,}" in *.mp4|*.mkv|*.webm|*.avi|*.mov|*.mpg|*.mpeg) return 0;; *) return 1;; esac; }
+is_image() { case "${1,,}" in *.png|*.jpg|*.jpeg|*.bmp|*.gif) return 0;; *) return 1;; esac; }
 
 if [[ -f "/storage/.config/emuelec/configs/novideo" ]] && [[ ${VIDEO} != "1" ]]; then
-    if [ "${ACTION_TYPE}" != "intro" ]; then
-        if [ "${SS_DEVICE}" == 1 ]; then
-            ${PLAYER} "${SPLASH}" > /dev/null 2>&1
+  if [ "${ACTION_TYPE}" != "intro" ]; then
+    BASE_VIDEO_DURATION="$(get_ee_setting ee_videoduration)"
+    BASE_IMAGE_DURATION="$(get_ee_setting ee_imageduration)"
+    EXIT_VIDEO_DURATION="$(get_ee_setting ee_exit_videoduration)"
+    EXIT_IMAGE_DURATION="$(get_ee_setting ee_exit_imageduration)"
+
+    VIDEO_DURATION="${BASE_VIDEO_DURATION}"
+    IMAGE_DURATION="${BASE_IMAGE_DURATION}"
+    if [ "${ACTION_TYPE}" = "exit" ]; then
+      [ -n "${EXIT_VIDEO_DURATION}" ] && VIDEO_DURATION="${EXIT_VIDEO_DURATION}"
+      [ -n "${EXIT_IMAGE_DURATION}" ] && IMAGE_DURATION="${EXIT_IMAGE_DURATION}"
+    fi
+
+    if is_image "${SPLASH}"; then
+      DUR="${IMAGE_DURATION:-3}"
+      if [ "${have_mpv}" -eq 1 ]; then
+        ${PLAYER_IMG} --fullscreen --no-keepaspect --vf="${MPV_VF}" --image-display-duration=${DUR} "${SPLASH}" >/dev/null 2>&1
+      else
+        ffplay -fs -autoexit -loglevel error -nostats -vf "${FILTER_FILL}" -t ${DUR} -loop 1 -framerate 1 -i "${SPLASH}" >/dev/null 2>&1
+      fi
+    elif is_video "${SPLASH}"; then
+      if [ -n "${VIDEO_DURATION}" ] && [ "${VIDEO_DURATION}" -gt 0 ]; then
+        if [ "${PLAYER_VID}" = "ffplay" ]; then
+          ${PLAYER_VID} -fs -autoexit -loglevel error -nostats -vf "${FILTER_FILL}" -t ${VIDEO_DURATION} -i "${SPLASH}" >/dev/null 2>&1
         else
-               if [[ "$EXTENSION" == "mp4" || "$EXTENSION" == "MP4" ]]; then
-                    if [[ -f "tmp/Plibretro.p" ]]; then
-                         ${PLAYER} -fs ${SIZE} -vf scale=${SCALE} "${SPLASH}" > /dev/null 2>&1
-                     else
-                         ${PLAYER} -fs -autoexit ${SIZE} -vf scale=${SCALE} "${SPLASH}" > /dev/null 2>&1
-                    fi
-                elif [ "${ACTION_TYPE}" == "exit" ]; then
-                # Game over presentation, 3 seconds for images or video duration + 3 seconds.
-                ${PLAYER} -fs ${SIZE} -vf scale=${SCALE}  "${SPLASH}" > /dev/null 2>&1 & sleep 3 && ACTION_TYPE="stopplayer"
-                else
-                   if [[ -f "tmp/Plibretro.p" ]]; then
-                     ${PLAYER} -fs ${SIZE} -vf scale=${SCALE} "${SPLASH}" > /dev/null 2>&1
-                   else
-                     ${PLAYER} -fs ${SIZE} -vf scale=${SCALE} -autoexit "${SPLASH}" > /dev/null 2>&1 & sleep 3 
-                   fi
-                fi
-            fi
-        fi 
+          ${PLAYER_VID} --fullscreen --no-keepaspect --vf="${MPV_VF}" --length=${VIDEO_DURATION} "${SPLASH}" >/dev/null 2>&1
+        fi
+      else
+        if [ "${PLAYER_VID}" = "ffplay" ]; then
+          ${PLAYER_VID} -fs -autoexit -loglevel error -nostats -vf "${FILTER_FILL}" -i "${SPLASH}" >/dev/null 2>&1
+        else
+          ${PLAYER_VID} --fullscreen --no-keepaspect --vf="${MPV_VF}" "${SPLASH}" >/dev/null 2>&1
+        fi
+      fi
+    fi
+  fi
 else
-    # Display intro video
-    RND=$(get_ee_setting "ee_randombootvideo.enabled" == "1")
-    if [ "${RND}" ==  1 ]; then
-        SPLASH=$(ls ${RANDOMVIDEO}/*.mp4 | sort -R | tail -1)
-        [[ -z "${SPLASH}" ]] && SPLASH="${VIDEOSPLASH}"
-    else
-        SPLASH="${VIDEOSPLASH}"
-    fi
-    set_audio alsa
-    # [ -e /storage/.config/asound.conf ] && mv /storage/.config/asound.conf /storage/.config/asound.confs
-    if [ ${SS_DEVICE} -eq 1 ]; then
-        ${PLAYER} "${SPLASH}" > /dev/null 2>&1
-    else
-        ${PLAYER} -fs -autoexit ${SIZE} -vf scale=${SCALE}  "${SPLASH}" > /dev/null 2>&1
-    fi
-    touch "/storage/.config/emuelec/configs/novideo"
-    # [ -e /storage/.config/asound.confs ] && mv /storage/.config/asound.confs /storage/.config/asound.conf
+  RND="$(get_ee_setting ee_randombootvideo.enabled)"
+  if [ "${RND}" = "1" ]; then
+    SPLASH="$(ls ${RANDOMVIDEO}/*.mp4 2>/dev/null | sort -R | tail -1)"
+    [[ -z "${SPLASH}" ]] && SPLASH="${VIDEOSPLASH}"
+  else
+    SPLASH="${VIDEOSPLASH}"
+  fi
+
+  set_audio alsa
+
+  if [ ${SS_DEVICE} -eq 1 ]; then
+    ${PLAYER_VID} --fullscreen --no-keepaspect --vf="${MPV_VF}" "${SPLASH}" >/dev/null 2>&1
+  else
+    ${PLAYER_VID} -fs -autoexit -vf "${FILTER_FILL}" -i "${SPLASH}" >/dev/null 2>&1
+  fi
+
+  touch "/storage/.config/emuelec/configs/novideo"
 fi
 
-if [ "${ACTION_TYPE}" == "stopplayer" ] ; then
-    killall "${PLAYER}"
-    #blank_buffer
-fi
-
-# Wait for the duration specified by ee_splash.delay in emuelec.conf
-SPLASHTIME=$(get_ee_setting ee_splash.delay)
-[ ! -z "${SPLASHTIME}" ] && sleep ${SPLASHTIME}
+SPLASHTIME="$(get_ee_setting ee_splash.delay)"
+[ -n "${SPLASHTIME}" ] && sleep "${SPLASHTIME}"

--- a/packages/sx05re/emuelec/config/emuelec/configs/emuelec.conf
+++ b/packages/sx05re/emuelec/config/emuelec/configs/emuelec.conf
@@ -63,6 +63,18 @@ ee_exitvideo.enabled=0
 ## Enable exit splash image (using /storage/roms/splash/exitsplash.png)
 ee_exitsplashimage.enabled=0
 
+## Set duration of splash LOADING screen in seconds
+ee_imageduration=3 
+
+## Set duration of splash EXIT screen in seconds
+ee_exit_imageduration=3
+
+## Set duration of splash LOADING video in seconds
+ee_videoduration=5            
+
+## Set duration of splash EXIT video in seconds
+ee_exit_videoduration=5
+
 ## Set video mode
 ee_videomode=1080p60hz
 


### PR DESCRIPTION
- Updated show_splash.sh: splash screens and videos for loading and exiting games are now always being displayed in fullscreen mode and their duration can now be easily set by four new variables inside emuelec.conf 

- emuelec.conf now has four added variables that set the duration in seconds:

ee_videoduration=5            
ee_exit_videoduration=5        

ee_imageduration=3            
ee_exit_imageduration=3