### PR TITLE
Update es_systems.cfg

### DIFF
--- a/packages/sx05re/emuelec-emulationstation/config/es_systems.cfg
+++ b/packages/sx05re/emuelec-emulationstation/config/es_systems.cfg
@@ -118,16 +118,16 @@ This file will be replaced on any new update of EmuELEC-->
 		</emulators>
 	</system>
 	<system>
-		<name>fmtmarty</name>
+		<name>fmtowns</name>
 		<fullname>FM Towns</fullname>
 		<manufacturer>Fujitsu</manufacturer>
 		<release>1989</release>
 		<hardware>computer</hardware>
 		<path>/storage/roms/fmtownsux</path>
- 		<extension>.cmd</extension>
+ 		<extension>.cmd .CMD</extension>
 		<command>emuelecRunEmu.sh %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers="%CONTROLLERSCONFIG%"</command>
-		<platform>fmtmarty</platform>
-		<theme>fmtmarty</theme>
+		<platform>fmtowns</platform>
+		<theme>fmtowns</theme>
 		<emulators>
 			<emulator name="libretro">
 				<cores>
@@ -1445,7 +1445,7 @@ This file will be replaced on any new update of EmuELEC-->
 		<release>1978</release>
 		<hardware>console</hardware>
 		<path>/storage/roms/videopac</path>
-		<extension>.bin .BIN</extension>
+		<extension>.bin .BIN .zip .ZIP</extension>
 		<command>emuelecRunEmu.sh %ROM% -P%SYSTEM% --core=%CORE% --emulator=%EMULATOR% --controllers="%CONTROLLERSCONFIG%"</command>
 		<platform>videopac</platform>
 		<theme>videopac</theme>


### PR DESCRIPTION
- Added .zip file extension to videopac

- Changes in FM Towns entry: name, platform and theme are now "fmtowns" instead of "fmtmarty" to allow recognition by screenscraper and also prevent possible display problems in themes that use "fmtowns" as tag for this system