### PR TITLE
[EE] emuelec-utils skip init_app_video and end_app_video for platform setup.

### DIFF
--- a/packages/sx05re/emuelec/bin/emuelec-utils
+++ b/packages/sx05re/emuelec/bin/emuelec-utils
@@ -457,6 +457,8 @@ function init_app_video() {
 	local ROMNAME=$2
 	local BASEROMNAME=${ROMNAME##*/}
 
+  [[ "${PLATFORM}" == "setup" ]] && return
+
 	blank_buffer
 
 	[[ -f "/tmp/EE_LASTVIDEO" ]] && return


### PR DESCRIPTION
[EE] emuelec-utils skip init_app_video and end_app_video for platform setup.

Removes annoying screen corruption during transitions for setup items.
