### PR TITLE
[EE] Dev launcher transition switch fixes

### DIFF
--- a/packages/sx05re/emuelec/bin/emuelec-utils
+++ b/packages/sx05re/emuelec/bin/emuelec-utils
@@ -457,6 +457,8 @@ function init_app_video() {
 	local ROMNAME=$2
 	local BASEROMNAME=${ROMNAME##*/}
 
+  [[ "${PLATFORM}" == "setup" ]] && return
+
 	[[ -f "/tmp/EE_LASTVIDEO" ]] && return
 
 	echo "$(cat /sys/class/display/mode)" > /tmp/EE_LASTVIDEO

--- a/packages/sx05re/emuelec/bin/emuelec-utils
+++ b/packages/sx05re/emuelec/bin/emuelec-utils
@@ -464,9 +464,10 @@ function init_app_video() {
 	local ROMNAME=$2
 	local BASEROMNAME=${ROMNAME##*/}
 
+	fbfix 0
+	fbfix 1
+
   if [[ "${PLATFORM}" == "setup" ]]; then 
-		fbfix 0
-		fbfix 1
 		return
 	fi
 
@@ -492,9 +493,10 @@ function end_app_video() {
 	local ROMNAME=$2
 	local BASEROMNAME=${ROMNAME##*/}
 
+	fbfix 0
+	fbfix 1
+
 	if [[ "${PLATFORM}" == "setup" ]]; then 
-		fbfix 0
-		fbfix 1
 		return
 	fi
 

--- a/packages/sx05re/emuelec/bin/emuelec-utils
+++ b/packages/sx05re/emuelec/bin/emuelec-utils
@@ -452,6 +452,13 @@ function createMultidisc() {
   echo -e "\n"
 }
 
+function blank_buffer() {
+# Clears screen buffer
+  # Blank the buffer.
+  dd if=/dev/zero of=/dev/fb0 bs=256K conv=sync,noerror,notrunc > /dev/null 2>&1
+  dd if=/dev/zero of=/dev/fb1 bs=256K conv=sync,noerror,notrunc > /dev/null 2>&1
+}
+
 function init_app_video() {
 	local PLATFORM=$1
 	local ROMNAME=$2
@@ -486,6 +493,8 @@ function end_app_video() {
 
 	# Show exit splash
 	${TBASH} show_splash.sh exit
+ 	
+	blank_buffer
 
 	fbfix 0
 	fbfix 1

--- a/packages/sx05re/emuelec/bin/emuelec-utils
+++ b/packages/sx05re/emuelec/bin/emuelec-utils
@@ -464,7 +464,10 @@ function init_app_video() {
 	local ROMNAME=$2
 	local BASEROMNAME=${ROMNAME##*/}
 
-  [[ "${PLATFORM}" == "setup" ]] && return
+  if [[ "${PLATFORM}" == "setup" ]]; then
+		 touch /tmp/EE_SKIP_APP_VIDEO
+		 return
+	fi
 
 	[[ -f "/tmp/EE_LASTVIDEO" ]] && return
 
@@ -484,6 +487,11 @@ function init_app_video() {
 }
 
 function end_app_video() {
+	if [[ -f "/tmp/EE_SKIP_APP_VIDEO" ]]; then
+		rm /tmp/EE_SKIP_APP_VIDEO
+		return
+	fi
+
 	local LAST_VIDEO="$(cat /tmp/EE_LASTVIDEO)"
 
 	[[ ! -f "/tmp/EE_LASTVIDEO" ]] && return
@@ -500,6 +508,7 @@ function end_app_video() {
 	fbfix 1
 
 	rm /tmp/EE_LASTVIDEO
+	rm /tmp/EE_SKIP_APP_VIDEO
 }
 
 function set_gptokeyb() {

--- a/packages/sx05re/emuelec/bin/emuelec-utils
+++ b/packages/sx05re/emuelec/bin/emuelec-utils
@@ -467,13 +467,14 @@ function init_app_video() {
 	fbfix 0
 	fbfix 1
 
-	echo $BASEROMNAME > /tmp/ee_romname
-
 	if [[ "${PLATFORM}" == "ports" ]] && [[ "${BASEROMNAME}" == "PortMaster.sh" ]]; then 
 		return
 	fi
 	
   if [[ "${PLATFORM}" == "setup" ]]; then 
+		blank_buffer
+		fbfix 0
+		fbfix 1
 		return
 	fi
 

--- a/packages/sx05re/emuelec/bin/emuelec-utils
+++ b/packages/sx05re/emuelec/bin/emuelec-utils
@@ -464,6 +464,7 @@ function init_app_video() {
 	local ROMNAME=$2
 	local BASEROMNAME=${ROMNAME##*/}
 
+	blank_buffer
 	fbfix 0
 	fbfix 1
 
@@ -472,9 +473,6 @@ function init_app_video() {
 	fi
 	
   if [[ "${PLATFORM}" == "setup" ]]; then 
-		blank_buffer
-		fbfix 0
-		fbfix 1
 		return
 	fi
 

--- a/packages/sx05re/emuelec/bin/emuelec-utils
+++ b/packages/sx05re/emuelec/bin/emuelec-utils
@@ -457,20 +457,21 @@ function init_app_video() {
 	local ROMNAME=$2
 	local BASEROMNAME=${ROMNAME##*/}
 
-	blank_buffer
-
 	[[ -f "/tmp/EE_LASTVIDEO" ]] && return
 
 	echo "$(cat /sys/class/display/mode)" > /tmp/EE_LASTVIDEO
 	local VIDEO_EMU=$(get_ee_setting nativevideo "${PLATFORM}" "${BASEROMNAME}")
 	[[ -z "$VIDEO_EMU" ]] && VIDEO_EMU=$(cat /tmp/EE_LASTVIDEO)
 
+	# Set the display video to that of the emulator setting.
+	[ ! -z "${VIDEO_EMU}" ] && ${TBASH} setres.sh "${VIDEO_EMU}" "${PLATFORM}" "${BASEROMNAME}" # set display
+
 	# Show splash screen if enabled
 	local SPL=$(get_ee_setting ee_splash.enabled)
 	[ "${SPL}" -eq "1" ] && ${TBASH} show_splash.sh gameloading "${PLATFORM}" "${ROMNAME}"
 
-	# Set the display video to that of the emulator setting.
-	[ ! -z "${VIDEO_EMU}" ] && ${TBASH} setres.sh "${VIDEO_EMU}" "${PLATFORM}" "${BASEROMNAME}" # set display
+	fbfix 0
+	fbfix 1
 }
 
 function end_app_video() {
@@ -484,7 +485,8 @@ function end_app_video() {
 	# Show exit splash
 	${TBASH} show_splash.sh exit
 
-  blank_buffer
+	fbfix 0
+	fbfix 1
 
 	rm /tmp/EE_LASTVIDEO
 }

--- a/packages/sx05re/emuelec/bin/emuelec-utils
+++ b/packages/sx05re/emuelec/bin/emuelec-utils
@@ -464,7 +464,11 @@ function init_app_video() {
 	local ROMNAME=$2
 	local BASEROMNAME=${ROMNAME##*/}
 
-  [[ "${PLATFORM}" == "setup" ]] && return
+  if [[ "${PLATFORM}" == "setup" ]]; then 
+		fbfix 0
+		fbfix 1
+		return
+	fi
 
 	[[ -f "/tmp/EE_LASTVIDEO" ]] && return
 
@@ -488,7 +492,11 @@ function end_app_video() {
 	local ROMNAME=$2
 	local BASEROMNAME=${ROMNAME##*/}
 
-	[[ "${PLATFORM}" == "setup" ]] && return
+	if [[ "${PLATFORM}" == "setup" ]]; then 
+		fbfix 0
+		fbfix 1
+		return
+	fi
 
 	local LAST_VIDEO="$(cat /tmp/EE_LASTVIDEO)"
 

--- a/packages/sx05re/emuelec/bin/emuelec-utils
+++ b/packages/sx05re/emuelec/bin/emuelec-utils
@@ -467,6 +467,12 @@ function init_app_video() {
 	fbfix 0
 	fbfix 1
 
+	echo $BASEROMNAME > /tmp/ee_romname
+
+	if [[ "${PLATFORM}" == "ports" ]] && [[ "${BASEROMNAME}" == "PortMaster.sh" ]]; then 
+		return
+	fi
+	
   if [[ "${PLATFORM}" == "setup" ]]; then 
 		return
 	fi
@@ -493,9 +499,15 @@ function end_app_video() {
 	local ROMNAME=$2
 	local BASEROMNAME=${ROMNAME##*/}
 
+	blank_buffer
+	
 	fbfix 0
 	fbfix 1
 
+	if [[ "${PLATFORM}" == "ports" ]] && [[ "${BASEROMNAME}" == "PortMaster.sh" ]]; then 
+		return
+	fi
+	
 	if [[ "${PLATFORM}" == "setup" ]]; then 
 		return
 	fi

--- a/packages/sx05re/emuelec/bin/emuelec-utils
+++ b/packages/sx05re/emuelec/bin/emuelec-utils
@@ -464,10 +464,7 @@ function init_app_video() {
 	local ROMNAME=$2
 	local BASEROMNAME=${ROMNAME##*/}
 
-  if [[ "${PLATFORM}" == "setup" ]]; then
-		 touch /tmp/EE_SKIP_APP_VIDEO
-		 return
-	fi
+  [[ "${PLATFORM}" == "setup" ]] && return
 
 	[[ -f "/tmp/EE_LASTVIDEO" ]] && return
 
@@ -487,10 +484,11 @@ function init_app_video() {
 }
 
 function end_app_video() {
-	if [[ -f "/tmp/EE_SKIP_APP_VIDEO" ]]; then
-		rm /tmp/EE_SKIP_APP_VIDEO
-		return
-	fi
+	local PLATFORM=$1
+	local ROMNAME=$2
+	local BASEROMNAME=${ROMNAME##*/}
+
+	[[ "${PLATFORM}" == "setup" ]] && return
 
 	local LAST_VIDEO="$(cat /tmp/EE_LASTVIDEO)"
 

--- a/packages/sx05re/emuelec/bin/emuelecRunApp.sh
+++ b/packages/sx05re/emuelec/bin/emuelecRunApp.sh
@@ -22,5 +22,5 @@ init_game
 
 "$@"
 
-[[ -z "${RUNEMU}" ]] && emuelec-utils end_app_video
+[[ -z "${RUNEMU}" ]] && emuelec-utils end_app_video "${PLATFORM}" "${ROMNAME}"
 end_game

--- a/packages/sx05re/emuelec/bin/emuelecRunEmu.sh
+++ b/packages/sx05re/emuelec/bin/emuelecRunEmu.sh
@@ -8,8 +8,6 @@
 
 # This whole file has become very hacky, I am sure there is a better way to do all of this, but for now, this works.
 
-blank_buffer
-
 if [ -f "/usr/bin/odroidgoa_utils.sh" ]; then
     DEFBRIGHT=$(get_ee_setting brightness.level)
     RACONF=/storage/.config/retroarch/retroarch.cfg
@@ -532,7 +530,6 @@ else
    ret_error=${?}
 fi
 
-#blank_buffer
 # clear terminal window
         reset > /dev/tty < /dev/null 2>&1
         reset > /dev/tty0 < /dev/null 2>&1
@@ -635,11 +632,11 @@ if [[ "${ret_error}" != "0" ]]; then
 
     # Since the error was not because of missing BIOS but we did get an error, display the log to find out
     [[ "${ret_bios}" == "0" ]] && text_viewer -e -w -t "Error! ${PLATFORM}-${EMULATOR}-${CORE}-${ROMNAME}" -f 24 ${EMUELECLOG}
-    blank_buffer
+    emuelec-utils blank_buffer
     exit 1
 else
     echo "exit 0" >> ${EMUELECLOG}
     echo "return_from_game" > /tmp/es_return_from_game
-    blank_buffer
+    emuelec-utils blank_buffer
     exit 0
 fi

--- a/packages/sx05re/emuelec/bin/emuelecRunEmu.sh
+++ b/packages/sx05re/emuelec/bin/emuelecRunEmu.sh
@@ -537,7 +537,6 @@ fi
         reset > /dev/console < /dev/null 2>&1
 
 # END loading
-[[ "${LIBRETRO}" = "yes" ]] && ${TBASH} show_splash.sh "stopplayer"
 
 emuelec-utils end_app_video "${PLATFORM}" "${ROMNAME}"
 

--- a/packages/sx05re/emuelec/bin/emuelecRunEmu.sh
+++ b/packages/sx05re/emuelec/bin/emuelecRunEmu.sh
@@ -539,7 +539,7 @@ fi
 # END loading
 [[ "${LIBRETRO}" = "yes" ]] && ${TBASH} show_splash.sh "stopplayer"
 
-emuelec-utils end_app_video
+emuelec-utils end_app_video "${PLATFORM}" "${ROMNAME}"
 
 emuelec-utils set_rotation "0" "${EMULATOR}"
 

--- a/packages/sx05re/emuelec/bin/setres.sh
+++ b/packages/sx05re/emuelec/bin/setres.sh
@@ -200,10 +200,12 @@ if [[ ! -z "${CUSTOM_RES}" ]]; then
   fi
 fi
 
-
-[[ ${OLD_MODE} != ${MODE} ]] && switch_resolution ${MODE}
+BLANK_BUFFER_CALLED=0
+if [[ ${OLD_MODE} != ${MODE} ]]; then
+	blank_buffer && BLANK_BUFFER_CALLED=1
+	switch_resolution ${MODE}
+fi
 MODE=$( cat ${FILE_MODE} )
-
 
 declare -a SIZE=($( get_resolution_size ${MODE} ${FBW} ${FBH}))
 
@@ -223,7 +225,7 @@ fi
 CURRENT_SIZE="$( fbset -fb /dev/fb${max_fb} | grep geometry | cut -d' ' -f2-3 )"
 NEW_SIZE="${FBW} ${FBH}"
 if [[ "${CURRENT_SIZE}" != "${NEW_SIZE}" ]]; then
-	blank_buffer >> /dev/null
+	[[ "${BLANK_BUFFER_CALLED}" == 0 ]] && blank_buffer
   echo "SET MAIN FRAME BUFFER"
   set_main_framebuffer ${FBW} ${FBH} 
 fi

--- a/packages/sx05re/emuelec/bin/setres.sh
+++ b/packages/sx05re/emuelec/bin/setres.sh
@@ -45,13 +45,14 @@ switch_resolution()
   # Here we first clear the primary display buffer of leftover artifacts then set
   # the secondary small buffers flag to stop copying across.
 #  blank_buffer >> /dev/null
-
+	echo 1 > /sys/class/graphics/fb${max_fb}/blank
   case ${MODE} in
     480cvbs|576cvbs|480p*|480i*|576p*|720p*|1080p*|1440p*|2160p*|576i*|720i*|1080i*|1440i*|2160i*|*x*)
       echo null > "${FILE_MODE}"
       sleep 1
       echo ${MODE} > "${FILE_MODE}"
   esac
+	echo 0 > /sys/class/graphics/fb${max_fb}/blank
 	NEW_MODE=$( cat ${FILE_MODE} )
 	[[ "${NEW_MODE}" != "${MODE}" ]] && exit 1
 }
@@ -200,9 +201,7 @@ if [[ ! -z "${CUSTOM_RES}" ]]; then
   fi
 fi
 
-BLANK_BUFFER_CALLED=0
 if [[ ${OLD_MODE} != ${MODE} ]]; then
-	blank_buffer && BLANK_BUFFER_CALLED=1
 	switch_resolution ${MODE}
 fi
 MODE=$( cat ${FILE_MODE} )
@@ -225,7 +224,7 @@ fi
 CURRENT_SIZE="$( fbset -fb /dev/fb${max_fb} | grep geometry | cut -d' ' -f2-3 )"
 NEW_SIZE="${FBW} ${FBH}"
 if [[ "${CURRENT_SIZE}" != "${NEW_SIZE}" ]]; then
-	[[ "${BLANK_BUFFER_CALLED}" == 0 ]] && blank_buffer
+	blank_buffer
   echo "SET MAIN FRAME BUFFER"
   set_main_framebuffer ${FBW} ${FBH} 
 fi

--- a/packages/sx05re/emuelec/bin/setres.sh
+++ b/packages/sx05re/emuelec/bin/setres.sh
@@ -44,7 +44,7 @@ switch_resolution()
 
   # Here we first clear the primary display buffer of leftover artifacts then set
   # the secondary small buffers flag to stop copying across.
-  blank_buffer >> /dev/null
+#  blank_buffer >> /dev/null
 
   case ${MODE} in
     480cvbs|576cvbs|480p*|480i*|576p*|720p*|1080p*|1440p*|2160p*|576i*|720i*|1080i*|1440i*|2160i*|*x*)
@@ -159,10 +159,6 @@ fi
 FBW=0
 FBH=0
 
-# Here we first clear the primary display buffer of leftover artifacts then set
-# the secondary small buffers flag to stop copying across.
-blank_buffer >> /dev/null
-
 # The current display mode before it may get changed below.
 OLD_MODE=$( cat ${FILE_MODE} )
 
@@ -174,7 +170,8 @@ BUFF=$(get_ee_setting ee_video_fb1_size)
 [[ -z "${BUFF}" ]] && BUFF=32
 
 if [[ -n "${BUFF}" ]] && [[ ${BUFF} > 0 ]]; then
-  fbset -fb /dev/fb1 -g ${BUFF} ${BUFF} ${BUFF} ${BUFF} ${BPP}
+	[[ "${max_fb}" == 0 ]] && fbset -fb /dev/fb1 -g ${BUFF} ${BUFF} ${BUFF} ${BUFF} ${BPP}
+	[[ "${max_fb}" == 1 ]] && fbset -fb /dev/fb0 -g ${BUFF} ${BUFF} ${BUFF} ${BUFF} ${BPP}
 fi
 
 # This is needed to reset scaling.
@@ -223,11 +220,12 @@ fi
 # Once we know the Width and Height is valid numbers we set the primary display
 # buffer, and we multiply the 2nd height by a factor of 2 I assume for interlaced 
 # support.
-CURRENT_MODE=$( cat ${FILE_MODE} )
-if [[ "${CURRENT_MODE}" == "${MODE}" ]]; then
+CURRENT_SIZE="$( fbset -fb /dev/fb${max_fb} | grep geometry | cut -d' ' -f2-3 )"
+NEW_SIZE="${FBW} ${FBH}"
+if [[ "${CURRENT_SIZE}" != "${NEW_SIZE}" ]]; then
+	blank_buffer >> /dev/null
   echo "SET MAIN FRAME BUFFER"
   set_main_framebuffer ${FBW} ${FBH} 
-  blank_buffer
 fi
 
 # Now that the primary buffer has been acquired we blank it again because the new

--- a/packages/sx05re/emuelec/bin/setres.sh
+++ b/packages/sx05re/emuelec/bin/setres.sh
@@ -44,7 +44,6 @@ switch_resolution()
 
   # Here we first clear the primary display buffer of leftover artifacts then set
   # the secondary small buffers flag to stop copying across.
-#  blank_buffer >> /dev/null
 	echo 1 > /sys/class/graphics/fb${max_fb}/blank
   case ${MODE} in
     480cvbs|576cvbs|480p*|480i*|576p*|720p*|1080p*|1440p*|2160p*|576i*|720i*|1080i*|1440i*|2160i*|*x*)
@@ -224,7 +223,7 @@ fi
 CURRENT_SIZE="$( fbset -fb /dev/fb${max_fb} | grep geometry | cut -d' ' -f2-3 )"
 NEW_SIZE="${FBW} ${FBH}"
 if [[ "${CURRENT_SIZE}" != "${NEW_SIZE}" ]]; then
-	blank_buffer
+	emuelec-utils blank_buffer
   echo "SET MAIN FRAME BUFFER"
   set_main_framebuffer ${FBW} ${FBH} 
 fi

--- a/packages/sx05re/emuelec/bin/show_splash.sh
+++ b/packages/sx05re/emuelec/bin/show_splash.sh
@@ -128,15 +128,18 @@ if [[ -f "/storage/.config/emuelec/configs/novideo" ]] && [[ ${VIDEO} != "1" ]];
 			DURATION="${EXIT_DURATION}"
     fi
 
-		if [ -z "${DURATION}" ] || [ ! -n ${DURATION} ] || [ ${DURATION} -lt 3 ]; then
-			DURATION=3
+		if [ -z "${DURATION}" ] || [ ! -n ${DURATION} ]; then
+			DURATION=2
 		fi
 
     if is_image "${SPLASH}"; then
       if [ "${have_mpv}" -eq 1 ]; then
         ${PLAYER_IMG} --fullscreen --no-keepaspect --vf="${MPV_VF}" --image-display-duration=${DURATION} "${SPLASH}" >/dev/null 2>&1
       else
-        ffplay -autoexit -fs -loglevel error -nostats -vf "${FILTER_FILL}" -i "${SPLASH}" -t ${DURATION} >/dev/null 2>&1 && sleep ${DURATION}
+        ffplay -fs -loglevel error -nostats -vf "${FILTER_FILL}" -i "${SPLASH}" -t ${DURATION} >/dev/null 2>&1 & PID=$!
+				sleep 1
+				kill ${PID}
+				sleep ${DURATION}
       fi
     elif is_video "${SPLASH}"; then
       if [ -n "${DURATION}" ] && [ "${DURATION}" -gt 0 ]; then

--- a/packages/sx05re/emuelec/bin/show_splash.sh
+++ b/packages/sx05re/emuelec/bin/show_splash.sh
@@ -29,7 +29,7 @@ PLATFORM=${PLATFORM,,}
 PLAYER_VID="ffplay"
 PLAYER_IMG="mpv"
 
-have_mpv=0; command -v mpv >/dev/null 2>&1 && have_mpv=1
+have_mpv=0
 
 case ${PLATFORM} in
   arcade|fba|fbn|neogeo|mame|cps*) PLATFORM="arcade" ;;

--- a/packages/sx05re/emuelec/bin/show_splash.sh
+++ b/packages/sx05re/emuelec/bin/show_splash.sh
@@ -122,26 +122,28 @@ if [[ -f "/storage/.config/emuelec/configs/novideo" ]] && [[ ${VIDEO} != "1" ]];
   if [ "${ACTION_TYPE}" != "intro" ]; then
     LOADING_DURATION="$(get_ee_setting ee_splash_loading_duration)"
     DURATION="${LOADING_DURATION}"
-		[ -z "${DURATION}" ] && DURATION=3
 
     if [ "${ACTION_TYPE}" = "exit" ]; then
 			EXIT_DURATION="$(get_ee_setting ee_splash_exit_duration)"
 			DURATION="${EXIT_DURATION}"
-			[ -z "${DURATION}" ] && DURATION=3
     fi
+
+		if [ -z "${DURATION}" ] || [ ! -n ${DURATION} ] || [ ${DURATION} -lt 3 ]; then
+			DURATION=3
+		fi
 
     if is_image "${SPLASH}"; then
       if [ "${have_mpv}" -eq 1 ]; then
         ${PLAYER_IMG} --fullscreen --no-keepaspect --vf="${MPV_VF}" --image-display-duration=${DURATION} "${SPLASH}" >/dev/null 2>&1
       else
-        ffplay -fs -loglevel error -nostats -vf "${FILTER_FILL}" -autoexit -i "${SPLASH}" >/dev/null 2>&1 && [[ -n "${DURATION}" ]] && [[ "${DURATION}" -gt 0 ]] && sleep ${DURATION}
+        ffplay -autoexit -fs -loglevel error -nostats -vf "${FILTER_FILL}" -i "${SPLASH}" -t ${DURATION} >/dev/null 2>&1 && sleep ${DURATION}
       fi
     elif is_video "${SPLASH}"; then
       if [ -n "${DURATION}" ] && [ "${DURATION}" -gt 0 ]; then
         if [ "${PLAYER_VID}" = "ffplay" ]; then
           ${PLAYER_VID} -fs -autoexit -loglevel error -nostats -vf "${FILTER_FILL}" -t ${DURATION} -i "${SPLASH}" >/dev/null 2>&1
         else
-          ${PLAYER_VID} --fullscreen --no-keepaspect --vf="${MPV_VF}" --length=${DURATION} "${SPLASH}" >/dev/null 2>&1
+          ${PLAYER_VID} --fullscreen --no-keepaspect --vf="${MPV_VF}" --length=${DURATION} "${SPLASH}" -t 1 >/dev/null 2>&1
         fi
       else
         if [ "${PLAYER_VID}" = "ffplay" ]; then

--- a/packages/sx05re/emuelec/bin/show_splash.sh
+++ b/packages/sx05re/emuelec/bin/show_splash.sh
@@ -134,7 +134,7 @@ if [[ -f "/storage/.config/emuelec/configs/novideo" ]] && [[ ${VIDEO} != "1" ]];
       if [ "${have_mpv}" -eq 1 ]; then
         ${PLAYER_IMG} --fullscreen --no-keepaspect --vf="${MPV_VF}" --image-display-duration=${DURATION} "${SPLASH}" >/dev/null 2>&1
       else
-        ffplay -fs -autoexit -loglevel error -nostats -vf "${FILTER_FILL}" -t ${DURATION} -loop 1 -framerate 1 -i "${SPLASH}" >/dev/null 2>&1
+        ffplay -fs -loglevel error -nostats -vf "${FILTER_FILL}" -autoexit -i "${SPLASH}" >/dev/null 2>&1 && [[ -n "${DURATION}" ]] && [[ "${DURATION}" -gt 0 ]] && sleep ${DURATION}
       fi
     elif is_video "${SPLASH}"; then
       if [ -n "${DURATION}" ] && [ "${DURATION}" -gt 0 ]; then

--- a/packages/sx05re/emuelec/profile.d/99-emuelec.conf
+++ b/packages/sx05re/emuelec/profile.d/99-emuelec.conf
@@ -70,17 +70,6 @@ hide_buffer () {
   echo ${1} > /sys/class/graphics/fb1/blank
 }
 
-blank_buffer() {
-# Clears screen buffer
-  # Blank the buffer.
-  echo 1 > /sys/class/graphics/fb0/blank
-  dd if=/dev/zero of=/dev/fb0 bs=256K conv=sync,noerror,notrunc > /dev/null 2>&1
-  echo 0 > /sys/class/graphics/fb0/blank
-	echo 1 > /sys/class/graphics/fb1/blank
-  dd if=/dev/zero of=/dev/fb1 bs=256K conv=sync,noerror,notrunc > /dev/null 2>&1
-  echo 0 > /sys/class/graphics/fb1/blank
-}
-
 aml_ver() {
 # Returns the Amlogic SOC version
 if grep -q "Gxl" /proc/device-tree/compatible; then

--- a/packages/sx05re/emulators/advancemame/bin/advmame.sh
+++ b/packages/sx05re/emulators/advancemame/bin/advmame.sh
@@ -73,6 +73,10 @@ CRASH_STACK_SIZE=$( ulimit -c )
 # Hack - Revert crash stack size so it can poo nicely.
 ulimit -c ${CRASH_STACK_SIZE}
 
+emuelec-utils blank_buffer
+
 ARG=$(echo basename ${2} | sed 's/\.[^.]*$//')
 ARG="$(echo ${2} | sed 's=.*/==;s/\.[^.]*$//')"
 SDL_AUDIODRIVER=alsa advmame ${ARG} -quiet
+
+emuelec-utils blank_buffer

--- a/packages/sx05re/tools/sysutils/fbfix/sources/fbfix.c
+++ b/packages/sx05re/tools/sysutils/fbfix/sources/fbfix.c
@@ -7,16 +7,38 @@
 #include <sys/mman.h>
 #include <stdlib.h>
 #include <sys/ioctl.h>
+#include <string.h>
+#include <ctype.h>
 
-int main()
+int main(int argc, char *argv[])
 {
+		if (argc != 2) {
+				fprintf(stderr, "Usage: %s <fb index 0-9>\n", argv[0]);
+				return 1;
+		}
+
+		// Validate argument
+		if (strlen(argv[1]) != 1 || !isdigit(argv[1][0])) {
+				fprintf(stderr, "Error: framebuffer index must be a single digit (0-9)\n");
+				return 1;
+		}
+
+		int fb_index = argv[1][0] - '0';
+		if (fb_index < 0 || fb_index > 9) {
+				fprintf(stderr, "Error: framebuffer index must be between 0 and 9\n");
+				return 1;
+		}
+
     int fbfd = 0;
     struct fb_var_screeninfo vinfo;
     struct fb_fix_screeninfo finfo;
 
+		// Build framebuffer path
+    char fb_path[16];
+    snprintf(fb_path, sizeof(fb_path), "/dev/fb%d", fb_index);
 
     /* Open the file for reading and writing */
-    fbfd = open("/dev/fb0", O_RDWR);
+    fbfd = open(fb_path, O_RDWR);
     if (!fbfd) 
     {
         printf("Error: cannot open framebuffer device.\n");

--- a/packages/sx05re/tools/sysutils/fbfix/sources/fbfix.c
+++ b/packages/sx05re/tools/sysutils/fbfix/sources/fbfix.c
@@ -13,19 +13,19 @@
 int main(int argc, char *argv[])
 {
 		if (argc != 2) {
-				fprintf(stderr, "Usage: %s <fb index 0-9>\n", argv[0]);
+				fprintf(stderr, "Usage: %s <fb index 0-3>\n", argv[0]);
 				return 1;
 		}
 
 		// Validate argument
 		if (strlen(argv[1]) != 1 || !isdigit(argv[1][0])) {
-				fprintf(stderr, "Error: framebuffer index must be a single digit (0-9)\n");
+				fprintf(stderr, "Error: framebuffer index must be a single digit (0-3)\n");
 				return 1;
 		}
 
 		int fb_index = argv[1][0] - '0';
-		if (fb_index < 0 || fb_index > 9) {
-				fprintf(stderr, "Error: framebuffer index must be between 0 and 9\n");
+		if (fb_index < 0 || fb_index > 3) {
+				fprintf(stderr, "Error: framebuffer index must be between 0 and 3\n");
 				return 1;
 		}
 


### PR DESCRIPTION
[EE] Dev launcher transition switch fixes

fbfix modification:
allows an integer to be passed to determine which fb index is to be reset.

setres.sh changes:
This PR aim to dramatically cut down calls to blank_buffer.

This also flips the show_splash and setres calls during loading. The show splash will have a stale frame during emulator loading. With the calls to fbfix after all emulators should show normally.

emuelec-utils change:
This combines PR https://github.com/EmuELEC/EmuELEC/pull/1541 as it is only one line of code.

Any transitions that present corruption please let me know the commands, the game, emulator, steps you took etc.

Testing procedures. Log into SSH and enter the following commands:
```
cd /emuelec/bin
wget https://raw.githubusercontent.com/EmuELEC/EmuELEC/f34f16a4fd2fa8d4683c2ac6400e1c75b96684dc/packages/sx05re/emuelec/bin/emuelec-utils -O emuelec-utils
wget https://raw.githubusercontent.com/EmuELEC/EmuELEC/f34f16a4fd2fa8d4683c2ac6400e1c75b96684dc/packages/sx05re/emuelec/bin/emuelecRunApp.sh -O emuelecRunApp.sh
wget https://raw.githubusercontent.com/EmuELEC/EmuELEC/f34f16a4fd2fa8d4683c2ac6400e1c75b96684dc/packages/sx05re/emuelec/bin/emuelecRunEmu.sh -O emuelecRunEmu.sh
wget https://raw.githubusercontent.com/EmuELEC/EmuELEC/f34f16a4fd2fa8d4683c2ac6400e1c75b96684dc/packages/sx05re/emuelec/bin/setres.sh -O setres.sh
wget https://raw.githubusercontent.com/EmuELEC/EmuELEC/f34f16a4fd2fa8d4683c2ac6400e1c75b96684dc/packages/sx05re/emuelec/bin/show_splash.sh -O show_splash.sh
chmod +x emuelec-utils
chmod +x emuelecRunEmu.sh
chmod +x emuelecRunApp.sh
chmod +x setres.sh
chmod +x show_splash.sh
```
To remove:
```
cd /emuelec/bin
mv emuelec-utils emuelec-utils.old
mv emuelecRunEmu.sh emuelecRunEmu.sh.old
mv emuelecRunApp.sh emuelecRunApp.sh.old
mv setres.sh setres.sh.old
mv show_splash.sh show_splash.sh.old
```
