### PR TITLE
[EE][Emulator] Amiberry - Screen placement fix.

### DIFF
--- a/packages/sx05re/emulators/amiberry/scripts/amiberry.start
+++ b/packages/sx05re/emulators/amiberry/scripts/amiberry.start
@@ -58,6 +58,11 @@ AMIBERRY_SET_CONF() {
 find_gamepad 
 }
 
+if [[ -f "${AMIBERRY_CONFIG_DIR}/amiberry.conf" ]]; then
+		HAS_ENTRY=$( cat "${AMIBERRY_CONFIG_DIR}/amiberry.conf" | grep -e '^default_correct_aspect_ratio=.*$' )
+		[[ -z "${HAS_ENTRY}" ]] && echo "default_correct_aspect_ratio=no" >> "${AMIBERRY_CONFIG_DIR}/amiberry.conf"
+fi
+
 # Check if we are loading a .zip file
 if [ `echo $1 | grep -i .zip | wc -l` -eq 1 ]; then
   


### PR DESCRIPTION
[EE][Emulator] Amiberry - Screen placement fix.

If the user has amiberry.conf usually generated on first launch. If the is no config record for "default_correct_aspect_ratio" it gets auto generated with the default being: default_correct_aspect_ratio=no.
