### PR TITLE
Amlogic-ce: fix reboot to FireOS condition for FireTV Cube

### DIFF
--- a/projects/Amlogic-ce/filesystem/usr/sbin/rebootfromnand
+++ b/projects/Amlogic-ce/filesystem/usr/sbin/rebootfromnand
@@ -8,7 +8,7 @@ DT_ID=$(cat /proc/device-tree/amlogic-dt-id 2>/dev/null | tr -d '\0')
 
 # Check if Fire TV Cube (g12brevb_raven_2g) 
 if [ "${DT_ID}" = "g12brevb_raven_2g" ]; then
-  /sbin/reboot quiescent
+  /bin/systemctl reboot --reboot-argument=quiescent
 else
   if /usr/sbin/fw_printenv whereToBootFrom > /dev/null 2>&1; then
     /usr/sbin/fw_setenv whereToBootFrom internal


### PR DESCRIPTION
I've written out the full reboot command to emmc argument for the 2nd gen Cube, because the quiescent argument wasn't being passed in the script when only using the reboot command.