### PR TITLE
Add joystick support for Homatics Gamepad

### DIFF
--- a/packages/sx05re/libretro_base/retroarch/udev.d/99-homatics-gamepad.rules
+++ b/packages/sx05re/libretro_base/retroarch/udev.d/99-homatics-gamepad.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="input", ATTRS{name}=="GAME", MODE="0666", ENV{ID_INPUT_JOYSTICK}="1"


### PR DESCRIPTION
By default gamepad is detected as keyboard & joystick, but functions as keyboard.  udev rule forces gamepad to identify as joystick.