### PR TITLE
Update theme names to match Batocera

### DIFF
--- a/packages/sx05re/emuelec-emulationstation/config/es_systems.json
+++ b/packages/sx05re/emuelec-emulationstation/config/es_systems.json
@@ -244,7 +244,7 @@
       "hardware": "arcade",
       "path": "/storage/roms/pgm2",
       "platform": "pgm2",
-      "theme": "pgm2",
+      "theme": "pgm",
       "command": "default",
       "extensions": [
         ".zip"
@@ -2329,7 +2329,7 @@
       "hardware": "console",
       "path": "/storage/roms/snesmsu1",
       "platform": "snes",
-      "theme": "snesmsu1",
+      "theme": "snes-msu1",
       "command": "default",
       "extensions": [
         ".7z",
@@ -3201,7 +3201,7 @@
       "hardware": "console",
       "path": "/storage/roms/megadrivemsu",
       "platform": "megadrive",
-      "theme": "megadrivemsu",
+      "theme": "megadrive-msu",
       "command": "default",
       "extensions": [
         ".7z",
@@ -3547,7 +3547,7 @@
       "hardware": "computer",
       "path": "/storage/roms/x1",
       "platform": "x1",
-      "theme": "sharpx1",
+      "theme": "x1",
       "command": "default",
       "extensions": [
         ".2d",
@@ -3885,7 +3885,7 @@
       "hardware": "console",
       "path": "/storage/roms/tic-80",
       "platform": "tic80",
-      "theme": "tic-80",
+      "theme": "tic80",
       "command": "default",
       "extensions": [
         ".tic"


### PR DESCRIPTION
snesmsu1 --> snes-msu1
megadrivemsu --> megadrive-msu
sharpx1 --> x1
tic-80 --> tic80

pgm2 --> pgm
Changed pgm2 to pgm to increase the chance that other themes include entry for this set of platforms