### PR TITLE
Melonds libretro full speed 60fps

### DIFF
--- a/distributions/EmuELEC/options
+++ b/distributions/EmuELEC/options
@@ -267,7 +267,7 @@
 # Space separated list is supported,
 # e.g. ADDITIONAL_PACKAGES="PACKAGE1 PACKAGE2"
   ADDITIONAL_PACKAGES="u-boot-script dtc CoreELEC-Debug-Scripts inject_bl301
-                       nfs-utils dtb-xml megatools"
+                       nfs-utils dtb-xml"
 
 # start SX05RE added options
 
@@ -363,6 +363,7 @@ desmume \
 desmume-2015 \
 lutro \
 melonds \
+melondsds \
 snes9x2005 \
 yabause"
 

--- a/packages/sx05re/emuelec-emulationstation/config/es_systems.json
+++ b/packages/sx05re/emuelec-emulationstation/config/es_systems.json
@@ -1712,8 +1712,11 @@
           "name": "libretro",
           "cores": [
             {
-              "name": "melonds",
+              "name": "melondsds",
               "default": true
+            },
+	    {
+	      "name": "melonds"
             },
             {
               "name": "desmume"

--- a/packages/sx05re/libretro/melonds/package.mk
+++ b/packages/sx05re/libretro/melonds/package.mk
@@ -41,10 +41,11 @@ PKG_USE_CMAKE="no"
 
 configure_target() {
   cd ${PKG_BUILD}
-  PKG_MAKE_OPTS_TARGET+=" HAVE_OPENGL=0 HAVE_NEON=1"
+  PKG_MAKE_OPTS_TARGET+=" HAVE_OPENGL=0 HAVE_NEON=1 HAVE_THREADS=1 JIT_ARCH=aarch64 HAVE_OPENGLES3=1"
 }
 
 makeinstall_target() {
   mkdir -p ${INSTALL}/usr/lib/libretro
   cp melonds_libretro.so ${INSTALL}/usr/lib/libretro/
 }
+

--- a/packages/sx05re/libretro/melondsds/package.mk
+++ b/packages/sx05re/libretro/melondsds/package.mk
@@ -1,0 +1,20 @@
+PKG_NAME="melondsds"
+PKG_VERSION="86986bfd82fb130d4d4739d93159acd986921808"
+PKG_LICENSE="GPLv3"
+PKG_SITE="https://github.com/JesseTG/melonds-ds"
+PKG_GIT_CLONE_BRANCH="dev"
+PKG_URL="${PKG_SITE}/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain ${OPENGLES} ${EGL}"
+
+PKG_SHORTDESC="An enhanced remake of the melonDS core for libretro that prioritizes standalone parity, reliability, and usability."
+PKG_TOOLCHAIN="cmake-make"
+
+PKG_CMAKE_OPTS_TARGET=" -DCMAKE_BUILD_TYPE=Release \
+                        -DCMAKE_RULE_MESSAGES=OFF \
+                        -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
+                        -DENABLE_OPENGL=OFF"
+
+makeinstall_target() {
+  mkdir -p ${INSTALL}/usr/lib/libretro
+  cp ${PKG_BUILD}/.${TARGET_NAME}/src/libretro/melondsds_libretro.so ${INSTALL}/usr/lib/libretro/
+}


### PR DESCRIPTION
This pull request updates the build configuration for the `melonds` package to enable additional features and optimizations for the target platform. The main change is the addition of new build flags to support threading, JIT compilation for `aarch64`, and OpenGL ES 3.

TESTED ODROID N2+

Build configuration enhancements:

* Updated the `configure_target` function in `package.mk` to add `HAVE_THREADS=1`, `JIT_ARCH=aarch64`, and `HAVE_OPENGLES3=1` to the build options, enabling threading, JIT for ARM64, and OpenGL ES 3 support.