### PR TITLE
Fix killall gptokeyb command syntax in 99-emuelec.conf

### DIFF
--- a/packages/sx05re/emuelec/profile.d/99-emuelec.conf
+++ b/packages/sx05re/emuelec/profile.d/99-emuelec.conf
@@ -270,7 +270,7 @@ set_video_controls() {
 }
 
 kill_video_controls() {
-    killall gptokeyb & > /dev/null 2>&1
+    killall gptokeyb > /dev/null 2>&1
 }
 
 dot_delete() {


### PR DESCRIPTION
Fix killall gptokeyb command syntax in 99-emuelec.conf

The command running in async is running the kill command sometimes runs after a new process has loading in killing off the gptokeyb process before the emulators even start. This causes users to not be able to exit games with gptokeyb because the new process gets killed off by the async killall command. The fix is simple, run the kill gptokeyb command BEFORE and WAIT until it's finished before creating another new process.
