### PR TITLE
[EE] Package Retroarch - Patch - Exit Menu Fix.

### DIFF
--- a/packages/sx05re/libretro_base/retroarch/patches/retroarch-10-Exit_menu.patch
+++ b/packages/sx05re/libretro_base/retroarch/patches/retroarch-10-Exit_menu.patch
@@ -27,9 +27,9 @@
 +      {
 +      /* Exit back to ES - TODO: Check if start.retro file exists, if it does, then exit with the following code */ 
 +     if( access( "/var/lock/start.retro", F_OK ) != -1 ) { remove("/var/lock/start.retro");
-+      system("touch /var/lock/start.games");
-+      system("systemctl restart emustation.service");
-+      system("systemctl stop retroarch.service"); 
++      system("touch /var/lock/start.retro");
++      system("systemctl restart retroarch.service");
++ //   system("systemctl stop retroarch.service");
 +      } }
 +      /* if it doesn't exist then just exit */
 +


### PR DESCRIPTION
[EE] Package Retroarch - Patch - Exit Menu Fix.

If the start.retro flag is present this patch fix will simply restart retroarch, instead of restarting into emustation.

Fix for old bug:
https://github.com/EmuELEC/EmuELEC/issues/320