### PR TITLE
[EE] Package Retroarch - Retroarch Configuration Overrides.

### DIFF
--- a/packages/sx05re/emuelec/bin/setsettings.sh
+++ b/packages/sx05re/emuelec/bin/setsettings.sh
@@ -621,3 +621,12 @@ cat "${RACONF}" >> "${LOG}"
 fi
  
 rm ${RACONF}
+
+RA_CONF_OVERRIDES="/storage/.config/retroarch/retroarch_overrides.cfg"
+if [[ -f "${RA_CONF_OVERRIDES}" ]]; then
+	ees -i ${RA_CONF_OVERRIDES}
+	if [[ "${LOGGING}" == "1" ]]; then
+		write_log "- merged retroarch_overrides.cfg settings to retroarch.cfg -"
+		cat "${RA_CONF_OVERRIDES}" >> "${LOG}"
+	fi
+fi

--- a/packages/sx05re/emuelec/bin/setsettings.sh
+++ b/packages/sx05re/emuelec/bin/setsettings.sh
@@ -626,7 +626,7 @@ RA_CONF_OVERRIDES="/storage/.config/retroarch/retroarch_overrides.cfg"
 if [[ -f "${RA_CONF_OVERRIDES}" ]]; then
 	ees -i ${RA_CONF_OVERRIDES}
 	if [[ "${LOGGING}" == "1" ]]; then
-		write_log "- merged retroarch_overrides.cfg settings to retroarch.cfg -"
+		write_log "- merged ${RA_CONF_OVERRIDES} settings to retroarch.cfg -"
 		cat "${RA_CONF_OVERRIDES}" >> "${LOG}"
 	fi
 fi


### PR DESCRIPTION
[EE] Package Retroarch - Retroarch Configuration Overrides.

Allows the user to enter into a seperate file config overrides that replace default entries from retroarch.cfg.

For example in retroarch.cfg there is value:
```
sort_savefiles_by_content_enable = "false"
```
In the same retroarch config directory there is file retroarch_overrides.cfg with:
```
sort_savefiles_by_content_enable = "true"
```
Then it will replace that value at the end when setsettings.sh is called via the emuelecRunEmu.sh script.

Testing Procedure SSH following commands:
```
cd /emuelec/bin
wget https://raw.githubusercontent.com/Langerz82/EmuELEC/ca5326d3df618a657b23d72839c2fd5e3e531626/packages/sx05re/emuelec/bin/setsettings.sh -O setsettings.sh
chmod +x setsettings.sh
RA_CONF="/storage/.config/retroarch/retroarch.cfg"
RA_CONF_OVERRIDES="/storage/.config/retroarch/retroarch_overrides.cfg"
cat ${RA_CONF} | grep sort_savefiles_by_content_enable
# should show value false
echo "sort_savefiles_by_content_enable = \"true\"" > "${RA_CONF_OVERRIDES}"
setsettings.sh
cat ${RA_CONF} | grep sort_savefiles_by_content_enable
# should show value true
```
Verify record value changed.

Adresses Issue:
https://github.com/EmuELEC/EmuELEC/issues/1569
