### PR TITLE
[setsettings.sh] Fix the RetroArch languages

### DIFF
--- a/packages/sx05re/emuelec/bin/setsettings.sh
+++ b/packages/sx05re/emuelec/bin/setsettings.sh
@@ -83,21 +83,20 @@ case "${EE_LANG}" in
     pt_BR|pt_PT) LANGEMUELEC="7" ;;
     en_US|en_GB) LANGEMUELEC="0" ;;
     fr_FR)       LANGEMUELEC="2" ;;
-    es_ES|es_MX) LANGEMUELEC="3" ;;
+    es_ES|es_MX|eu_ES) LANGEMUELEC="3" ;;
     de_DE)       LANGEMUELEC="4" ;;
     it_IT)       LANGEMUELEC="5" ;;
-    eu_ES)       LANGEMUELEC="21" ;;
-    tr_TR)       LANGEMUELEC="17" ;;
+    tr_TR)       LANGEMUELEC="18" ;;
     zh_CN)       LANGEMUELEC="12" ;;
     zh_TW)       LANGEMUELEC="11" ;;
     ko_KR)       LANGEMUELEC="10" ;;
-    ja_JP)       LANGEMUELEC="9" ;;
-    ru_RU)       LANGEMUELEC="14" ;;
-    nl_NL)       LANGEMUELEC="8" ;;
-    pl_PL)       LANGEMUELEC="15" ;;
-    sv_SE)       LANGEMUELEC="16" ;;
-    hu_HU)       LANGEMUELEC="19" ;;
-    cs_CZ)       LANGEMUELEC="20" ;;
+    ja_JP)       LANGEMUELEC="1" ;;
+    ru_RU)       LANGEMUELEC="9" ;;
+    nl_NL)       LANGEMUELEC="6" ;;
+    pl_PL)       LANGEMUELEC="14" ;;
+    sv_SE)       LANGEMUELEC="25" ;;
+    hu_HU)       LANGEMUELEC="31" ;;
+    cs_CZ)       LANGEMUELEC="27" ;;
     *)           LANGEMUELEC="0" ;;
 esac
 


### PR DESCRIPTION
From the RetroArch app:
0  en_US English
1  ja_JP Japanese - 日本語 [75-95%]
2  fr_FR French - Français [>95 %]
3  es_ES Spanish - Español [>95 %]
4  de_DE German - Deutsch [>95 %]
5  it_IT Italian - Italiano [>95%]
6  nl_NL Dutch - Nederlands [25-49%]
7  pt_BR Portuguese (Brazil) - Português (Brasil) [>95%]
8  pt_PT Portuguese (Portugal) - Português (Portugal) [25-49%]
9  ru_RU Russian - Русский язык [>95%]
10 ko_KR Korean - 한국어 (Restart required) [>95%]
11 zh_TW Chinese (Traditional) - 繁體中文 (Restart required) [75~95%]
12 zh_CN Chinese (Simplified) - 简体中文 (Restart required) [>95%]
13 eo Esperanto - Esperanto [<25%]
14 pl_PL Polish - Polski [75-95%]
15 vi_VN Vietnamese - Tiếng Việt [>95%]
16 ar_SA Arabic - (███████████████ - Restart required) [25-49%]
17 el_GR Greek - Ελληνικά [<25%]
18 tr_TR Turkish - Türkçe [>95%]
19 sk_SK Slovak - Slovenčina [<25%]
20 fa_IR Persian - (█████ - Restart required) [<25%]
21 he_IL Hebrew - עִבְרִית [<25%]
22 ast_ES Asturian - Asturianu [<25%]
23 fi_FI Finnish - Suomi [50-74 %]
24 id_ID Indonesian - Bahasa Indonesia [<25%]
25 sv_SE Swedish - Svenska [>95%]
26 uk_UA Ukrainian - Українська мова [>95%]
27 cs_CZ Czech - Čeština [75-95%]
28 ca_ES Catalan (Valencian) - Català (Valencià) [<25%]
29 ca_ES Catalan - Català [>95%]
30 en_GB English (United Kingdom) [75-95%]
31 hu_HU Hungarian - Magyar [>95%]
32 be_BY Belarusian - Беларуская мова [75-95 %]
33 gl_ES Galician - Galego [>95%]
34 nb_NO Norwegian - Norsk [<25%]
35 ga_IE Irish - Gaeilge [>95%]

Note: eu_ES (Basque) is not available in RetroArch, es_ES is used instead.