### PR TITLE
[EE] package sdljoytest - gamepad_info - udev name fix.

### DIFF
--- a/packages/sx05re/emuelec/bin/joy_common.sh
+++ b/packages/sx05re/emuelec/bin/joy_common.sh
@@ -20,7 +20,7 @@ GAMEPAD_INFO_ALL="/tmp/jc/gamepad_info.txt"
 
 jc_get_config() {
   local GP_FILE="/tmp/jc/js${1}"
-  cat ${GAMEPAD_INFO_ALL} | grep -E -A5 "^Gamepad js${1}$" > ${GP_FILE}
+  cat ${GAMEPAD_INFO_ALL} | grep -E -A6 "^Gamepad js${1}$" > ${GP_FILE}
   [[ -z ${GP_FILE} ]] && echo ' ' && return
 
   mapfile -t GAMEPAD_INFO < "${GP_FILE}"

--- a/packages/sx05re/emuelec/bin/joy_common.sh
+++ b/packages/sx05re/emuelec/bin/joy_common.sh
@@ -30,8 +30,9 @@ jc_get_config() {
   local DEVICE_GUID="$( echo "${GAMEPAD_INFO[3]}" | cut -c18- )"
   local JOYMAPPING="$( echo "${GAMEPAD_INFO[4]}" | cut -c18- )"
   local INSTANCE_ID="$( echo "${GAMEPAD_INFO[5]}" | cut -c18- )"
+  local JS_INDEX="$( echo "${GAMEPAD_INFO[6]}" | cut -c18- )"
 
-  echo $(( $1 + 1 )) js${1} ${DEVICE_GUID} \"${JOY_UDEV_NAME}\" \"${JOYMAPPING}\" \"${JOY_SDL_NAME}\"
+  echo $(( $1 + 1 )) js${JS_INDEX} ${DEVICE_GUID} \"${JOY_UDEV_NAME}\" \"${JOYMAPPING}\" \"${JOY_SDL_NAME}\"
 }
 
 jc_get_players() {

--- a/packages/sx05re/emuelec/bin/joy_common.sh
+++ b/packages/sx05re/emuelec/bin/joy_common.sh
@@ -20,7 +20,7 @@ GAMEPAD_INFO_ALL="/tmp/jc/gamepad_info.txt"
 
 jc_get_config() {
   local GP_FILE="/tmp/jc/js${1}"
-  cat ${GAMEPAD_INFO_ALL} | grep -E -A6 "^Gamepad js${1}$" > ${GP_FILE}
+  cat ${GAMEPAD_INFO_ALL} | grep -E -A6 "^Gamepad ${1}$" > ${GP_FILE}
   [[ -z ${GP_FILE} ]] && echo ' ' && return
 
   mapfile -t GAMEPAD_INFO < "${GP_FILE}"


### PR DESCRIPTION
[EE] package sdljoytest - gamepad_info - udev name fix.

Required PR Dependency:
https://github.com/EmuELEC/sdljoytest/pull/2

Fixes issue:
https://github.com/EmuELEC/EmuELEC/issues/1607
