### PR TITLE
[EE] file joy_common.sh - Added ES priority ordering. (auth: pmsobrado)

### DIFF
--- a/packages/sx05re/emuelec/bin/joy_common.sh
+++ b/packages/sx05re/emuelec/bin/joy_common.sh
@@ -6,6 +6,8 @@
 
 # 08/01/23 - Joshua L - Modified get GUID thanks to shantigilbert.
 # 16/10/25 - Joshua L - Modified uses sdljoytest.
+# 22/02/26 - Joshua L - Added js instance ID.
+# 23/02/26 - Pablo S - Added ES Ordering fixes. (https://github.com/pmsobrado)
 
 # Source predefined functions and variables
 . /etc/profile
@@ -14,35 +16,89 @@ GCDB="${SDL_GAMECONTROLLERCONFIG_FILE}"
 
 EMULATOR="${1}"
 
+FIXED_ORDER=0
+[[ "${2}" == "fixed_order" ]] && FIXED_ORDER=1
+
 mkdir -p "/tmp/jc"
 
 GAMEPAD_INFO_ALL="/tmp/jc/gamepad_info.txt"
 
-jc_get_config() {
-  local GP_FILE="/tmp/jc/js${1}"
-  cat ${GAMEPAD_INFO_ALL} | grep -E -A5 "^Gamepad js${1}$" > ${GP_FILE}
-  [[ -z ${GP_FILE} ]] && echo ' ' && return
+CONTROLLERS_PRIORITY_DATA=
+[[ -f "/tmp/controllerconfig.txt" ]] && CONTROLLERS_PRIORITY_DATA=$(cat "/tmp/controllerconfig.txt")
 
-  mapfile -t GAMEPAD_INFO < "${GP_FILE}"
+
+jc_get_config() {
+  local GAMEPAD_DATA=$(cat ${GAMEPAD_INFO_ALL} | grep -E -A6 "^Gamepad ${1}$")
+  [[ -z "${GAMEPAD_DATA}" ]] && echo '' && return
+
+  mapfile -t GAMEPAD_INFO < <(echo "${GAMEPAD_DATA}")
 
   local JOY_UDEV_NAME="$( echo "${GAMEPAD_INFO[1]}" | cut -c18- )"
   local JOY_SDL_NAME="$( echo "${GAMEPAD_INFO[2]}" | cut -c18- )"
   local DEVICE_GUID="$( echo "${GAMEPAD_INFO[3]}" | cut -c18- )"
   local JOYMAPPING="$( echo "${GAMEPAD_INFO[4]}" | cut -c18- )"
   local INSTANCE_ID="$( echo "${GAMEPAD_INFO[5]}" | cut -c18- )"
+  local JS_INDEX="$( echo "${GAMEPAD_INFO[6]}" | cut -c18- )"
 
-  echo $(( $1 + 1 )) js${1} ${DEVICE_GUID} \"${JOY_UDEV_NAME}\" \"${JOYMAPPING}\" \"${JOY_SDL_NAME}\"
+  echo js${JS_INDEX} ${DEVICE_GUID} \"${JOY_UDEV_NAME}\" \"${JOYMAPPING}\" \"${JOY_SDL_NAME}\"
+}
+
+jc_get_order_indexes() {
+  local MAX_VALUE=$1
+  shift
+  local GUIDS=(${@})
+  local PLAYER_ORDER=()
+  for i in {0..3}; do
+    local CURRENT_GUID=${GUIDS[${i}]}
+    local PINDEX=
+
+    # 1. Get player for this physical index (jci)
+    if [[ ! -z "${CURRENT_GUID}" ]] && [[ ! -z "${CONTROLLERS_PRIORITY_DATA}" ]]; then
+      local priority_record=$( echo "${CONTROLLERS_PRIORITY_DATA}" | grep -o "\-p[1-4]index [0-9] -p[1-4]guid ${CURRENT_GUID}" | head -n1 )
+      if [[ ! -z "${priority_record}" ]]; then
+        CONTROLLERS_PRIORITY_DATA=$( echo $CONTROLLERS_PRIORITY_DATA | sed "s/${priority_record}//g" )
+        PINDEX=$(echo "${priority_record}" | cut -c3 )
+        [[ -n "${PINDEX}" ]] && PINDEX=$(( PINDEX - 1 ))
+      fi
+    fi
+
+    # 2. If it does not exist on the priority settings, assign default one but respecting reserved joypad slots
+    if [[ ! -n "${PINDEX}" ]]; then
+      for (( i = 0; i < MAX_VALUE; i++ ))
+      do
+        PINDEX=$i
+        [[ ! " ${PLAYER_ORDER[@]} " =~ " ${PINDEX} " ]] && break
+      done
+    fi
+    PLAYER_ORDER+=("${PINDEX}")
+  done
+  echo "${PLAYER_ORDER[@]}"
 }
 
 jc_get_players() {
   gamepad_info -more > ${GAMEPAD_INFO_ALL}
 
-  for jci in {0..3}; do
-    CFG=$( jc_get_config "${jci}" )
-    CFG_CLEAN=${CFG}
-    [[ -z "${CFG}" ]] && CFG_CLEAN=$(( $jci + 1 ))
-    echo ${CFG}
-    eval clean_pad ${CFG_CLEAN}
-    [[ ! -z "${CFG}" ]] && eval set_pad ${CFG}
+  declare -a player_cfgs=()
+  declare -a player_guids=()
+
+  for i in {0..3}; do
+    local CFG=$( jc_get_config "${i}" )
+    local GUID=$(echo "${CFG}" | awk '{print $2}')
+
+    [[ ! -z "${GUID}" ]] && player_guids+=("${GUID}")
+    player_cfgs+=("${CFG}")
+  done
+
+  local player_order=(0 1 2 3)
+  if [[ "${FIXED_ORDER}" == "0" ]]; then
+    player_order=($( jc_get_order_indexes 4 "${player_guids[@]}"))
+  fi
+
+  for i in {0..3}; do
+      local pi=$(( i + 1 ))
+      clean_pad ${pi}
+      local order=${player_order[${i}]}
+      local cfg=${player_cfgs[${order}]}
+      [[ ! -z "${cfg}" ]] && eval set_pad ${pi} ${cfg} ${order}
   done
 }

--- a/packages/sx05re/emulators/PPSSPPSDL/scripts/set_ppsspp_joy.sh
+++ b/packages/sx05re/emulators/PPSSPPSDL/scripts/set_ppsspp_joy.sh
@@ -14,7 +14,7 @@ CONFIG=${CONFIG_DIR}/controls.ini
 CONFIG_TMP=/tmp/jc/ppsspp.tmp
 
 
-source joy_common.sh "ppsspp"
+source joy_common.sh "ppsspp" "fixed_order"
 
 declare -A GC_PPSSPP_VALUES=(
   [h0.1]="10-19" #Up


### PR DESCRIPTION
[EE] file joy_common.sh - Added ES priority ordering. (auth: pmsobrado & Langerz82)

Incorporated PR:
[EE] package sdljoytest - gamepad_info - udev name fix. (https://github.com/EmuELEC/EmuELEC/pull/1608)

Depends on:
https://github.com/EmuELEC/sdljoytest/pull/2

Fixes:
https://github.com/EmuELEC/EmuELEC/issues/1607

Issue Reference:
https://github.com/EmuELEC/EmuELEC/issues/1607#issuecomment-3941444587

Credits:
Pablo S [pmsobrado](https://github.com/pmsobrado)
[Langerz82](https://github.com/Langerz82)