### PR TITLE
[EE] Package emuelec - setsettings.sh added sdl to udev ordering

### DIFF
--- a/packages/sx05re/emuelec/bin/setsettings.sh
+++ b/packages/sx05re/emuelec/bin/setsettings.sh
@@ -573,6 +573,8 @@ for i in 1 2 3 4 5; do
 if [[ "${CONTROLLERS}" == *p${i}* ]]; then
 PINDEX="${CONTROLLERS#*-p${i}index }"
 PINDEX="${PINDEX%% -p${i}guid*}"
+PINDEX_UDEV=$(sdl_udev_joystick_map "${PINDEX}")
+[[ -n "${PINDEX_UDEV}" ]] && PINDEX=${PINDEX_UDEV}
 echo "input_player${i}_joypad_index = \"${PINDEX}\"" >> ${RACONF}
 
 # Setting controller type for different cores


### PR DESCRIPTION
[EE] Package emuelec - setsettings.sh added sdl to udev ordering

depends on - sdljoytest:
https://github.com/EmuELEC/sdljoytest/pull/3

**Testing:**
You need sdl_udev_joystick_map in /emuelec/bin and with exec permissions (from build of sdljoytest).
```
cd /emuelec/bin
wget https://raw.githubusercontent.com/Langerz82/EmuELEC/7f7aeec5baa8e86107dd42512ef73a73ba3ec15a/packages/sx05re/emuelec/bin/setsettings.sh -O setsettings.sh
chmod +x setsettings.sh
```