### PR TITLE
[EE] package sdljoytest, emuelec - sdl_ra_joystick_map retroarch ordering fix

### DIFF
--- a/packages/sx05re/emuelec/bin/setsettings.sh
+++ b/packages/sx05re/emuelec/bin/setsettings.sh
@@ -573,6 +573,8 @@ for i in 1 2 3 4 5; do
 if [[ "${CONTROLLERS}" == *p${i}* ]]; then
 PINDEX="${CONTROLLERS#*-p${i}index }"
 PINDEX="${PINDEX%% -p${i}guid*}"
+PINDEX_UDEV=$(sdl_ra_joystick_map "${PINDEX}")
+[[ -n "${PINDEX_UDEV}" ]] && PINDEX=${PINDEX_UDEV}
 echo "input_player${i}_joypad_index = \"${PINDEX}\"" >> ${RACONF}
 
 # Setting controller type for different cores

--- a/packages/sx05re/tools/sysutils/sdljoytest/package.mk
+++ b/packages/sx05re/tools/sysutils/sdljoytest/package.mk
@@ -20,4 +20,5 @@ mkdir -p ${INSTALL}/usr/bin
 cp -rf test_gamepad_SDL2 ${INSTALL}/usr/bin/sdljoytest
 cp -rf map_gamepad_SDL2 ${INSTALL}/usr/bin/sdljoymap
 cp -rf gamepad_info ${INSTALL}/usr/bin/gamepad_info
+cp -rf sdl_ra_joystick_map ${INSTALL}/usr/bin/sdl_ra_joystick_map
 }


### PR DESCRIPTION
[EE] package sdljoytest, emuelec - sdl_ra_joystick_map retroarch ordering fix

Depends on:
https://github.com/EmuELEC/sdljoytest/pull/4

**Testing:**
You need sdl_ra_joystick_map in /emuelec/bin and with exec permissions (from build of sdljoytest).
```
cd /emuelec/bin
wget https://raw.githubusercontent.com/Langerz82/EmuELEC/94fc32d3472d3d085eabab5858d6aefc49a53d2e/packages/sx05re/emuelec/bin/setsettings.sh -O setsettings.sh
chmod +x setsettings.sh
```

Credits https://github.com/pmsobrado :
For testing this fix.

Fix for issue:
https://github.com/EmuELEC/EmuELEC/issues/1620
