### PR TITLE
Added libretro core Mu, a Palm OS emulator

### DIFF
--- a/distributions/EmuELEC/options
+++ b/distributions/EmuELEC/options
@@ -331,6 +331,7 @@ mgba \
 minivmac \
 mojozork \
 mrboom \
+mu \
 mupen64plus \
 neocd_libretro \
 nestopia \

--- a/packages/sx05re/emuelec-emulationstation/config/es_features.cfg
+++ b/packages/sx05re/emuelec-emulationstation/config/es_features.cfg
@@ -58,6 +58,7 @@
 	  <core name="minivmac" features="netplay, rewind, autosave" />
       <core name="mrboom" features="netplay, rewind, autosave" />
 	  <core name="mojozork" features="netplay, rewind, autosave" />
+	  <core name="mu" features="netplay, rewind, autosave" />
       <core name="mupen64plus_next" features="netplay, rewind, autosave, cheevos" />
       <core name="nekop2" features="netplay, rewind, autosave, midi" />
       <core name="neocd" features="netplay, rewind, autosave, vertical" />

--- a/packages/sx05re/emuelec-emulationstation/config/es_systems.json
+++ b/packages/sx05re/emuelec-emulationstation/config/es_systems.json
@@ -4615,6 +4615,35 @@
       ]
     },
 	{
+      "name": "palm",
+      "fullname": "Palm OS (m515)",
+      "manufacturer": "Palm",
+      "release": "2002",
+      "hardware": "handheld",
+      "path": "/storage/roms/palm",
+      "platform": "palm",
+      "theme": "palm",
+      "command": "default",
+      "extensions": [
+        ".prc",
+        ".pdb",
+        ".img",
+        ".zip",
+        ".7z"
+      ],
+      "emulators": [
+        {
+          "name": "libretro",
+          "cores": [
+            {
+              "name": "mu",
+              "default": true
+            }
+          ]
+        }
+      ]
+    },
+	{
       "name": "archimedes",
       "fullname": "Archimede",
       "manufacturer": "Acorn Computers",

--- a/packages/sx05re/libretro/mu/package.mk
+++ b/packages/sx05re/libretro/mu/package.mk
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2024 JELOS (https://github.com/JustEnoughLinuxOS)
+
+PKG_NAME="mu"
+PKG_VERSION="de05588fcb1adca6738dc4cf6a2e6e6c447bf2f2"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="CC BY-NC 3.0 US"
+PKG_SITE="https://github.com/libretro/Mu"
+PKG_URL="$PKG_SITE.git"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_PRIORITY="optional"
+PKG_SECTION="libretro"
+PKG_SHORTDESC="An emulator for the Palm m515 OS ported to libretro."
+PKG_LONGDESC="An emulator for the Palm m515 OS ported to libretro. It is intended to avoid hacks like those used by the POSE emulator, where API calls are intercepted and replaced with those that don't use the actual hardware."
+
+PKG_IS_ADDON="no"
+PKG_TOOLCHAIN="make"
+PKG_AUTORECONF="no"
+
+make_target() {
+  make -C ${PKG_BUILD}/libretroBuildSystem/
+}
+
+makeinstall_target() {
+  mkdir -p ${INSTALL}/usr/lib/libretro
+  cp ${PKG_BUILD}/libretroBuildSystem/mu_libretro.so ${INSTALL}/usr/lib/libretro/
+}


### PR DESCRIPTION
- added package.mk for libretro core "mu_libretro.so"

- updated options, es_features.cfg and es_systems.json