### PR TITLE
Added BigInstinct 1.0, an emulator especially made for Killer Instinct 1 & 2

### DIFF
--- a/packages/sx05re/emuelec-emulationstation/config/es_features.cfg
+++ b/packages/sx05re/emuelec-emulationstation/config/es_features.cfg
@@ -140,4 +140,5 @@
   <emulator name="oricutron" features="nativevideo" />
   <emulator name="eka2l1" features="nativevideo" />
   <emulator name="bigpemu" features="nativevideo" />
+  <emulator name="biginstinct" features="nativevideo" />
 </features>

--- a/packages/sx05re/emuelec-emulationstation/config/es_systems.json
+++ b/packages/sx05re/emuelec-emulationstation/config/es_systems.json
@@ -90,6 +90,7 @@
       "extensions": [
         ".7z",
         ".cmd",
+		".bighard",
         ".zip"
       ],
       "emulators": [
@@ -144,6 +145,7 @@
       "extensions": [
         ".7z",
         ".cmd",
+		".bighard",
         ".zip"
       ],
       "emulators": [
@@ -1221,6 +1223,7 @@
       "command": "default",
       "extensions": [
         ".7z",
+		".bighard",
         ".zip"
       ],
       "emulators": [

--- a/packages/sx05re/emuelec/bin/emuelecRunEmu.sh
+++ b/packages/sx05re/emuelec/bin/emuelecRunEmu.sh
@@ -155,7 +155,12 @@ emuelec-utils init_app_video "${PLATFORM}" "${ROMNAME}"
 CONTROLLERCONFIG="${arguments#*--controllers=*}"
 echo "${CONTROLLERCONFIG}" | tr -d '"' > "/tmp/controllerconfig.txt"
 
-if [ -z ${LIBRETRO} ] && [ -z ${RETRORUN} ]; then
+# .bighard files always go to BigInstinct, regardless of platform/emu choice
+if [[ "${ROMNAME,,}" == *.bighard ]]; then
+    set_kill_keys "biginstinct"
+    RUNTHIS='${TBASH} biginstinctstart.sh "${ROMNAME}"'
+
+elif [ -z ${LIBRETRO} ] && [ -z ${RETRORUN} ]; then
 
 GPTOKEYB=$(get_ee_setting "gptokeyb" "${PLATFORM}" "${BASEROMNAME}")
 VIRTUAL_KB=

--- a/packages/sx05re/emuelec/package.mk
+++ b/packages/sx05re/emuelec/package.mk
@@ -11,7 +11,7 @@ PKG_LONGDESC="EmuELEC Meta Package"
 PKG_TOOLCHAIN="manual"
 
 PKG_EXPERIMENTAL="nestopiaCV quasi88 xmil np2kai hypseus-singe yabasanshiroSA_1_11 yabasanshiroSA_1_5 fbneoSA same_cdi ikemen-go" 
-PKG_EMUS="${LIBRETRO_CORES} desmume melonds advancemame PPSSPPSDL amiberry amiberry-lite hatarisa openbor dosbox-staging mupen64plus-nx mupen64plus-nx-alt scummvmsa stellasa solarus dosbox-pure pcsx_rearmed ecwolf potator freej2me duckstation flycastsa fmsx-libretro jzintv mupen64plussa xroar x16 simcoupe ti99sim oricutron eka2l1 bigpemu"
+PKG_EMUS="${LIBRETRO_CORES} desmume melonds advancemame PPSSPPSDL amiberry amiberry-lite hatarisa openbor dosbox-staging mupen64plus-nx mupen64plus-nx-alt scummvmsa stellasa solarus dosbox-pure pcsx_rearmed ecwolf potator freej2me duckstation flycastsa fmsx-libretro jzintv mupen64plussa xroar x16 simcoupe ti99sim oricutron eka2l1 bigpemu biginstinct"
 PKG_DEPENDS_TARGET+=" emuelec-tools ${PKG_EMUS} ${PKG_EXPERIMENTAL}"
 
 

--- a/packages/sx05re/emulators/biginstinct/package.mk
+++ b/packages/sx05re/emulators/biginstinct/package.mk
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2024-present EmuELEC Team (https://github.com/EmuELEC/EmuELEC)
+
+PKG_NAME="biginstinct"
+PKG_VERSION="10"
+PKG_SHA256="5c29befbabefa6f65c60149de670e382101a315f41a20cdd2e738d59268c1629"
+PKG_ARCH="aarch64"
+PKG_LICENSE="Proprietary"
+PKG_SITE="https://www.richwhitehouse.com/ki"
+PKG_URL="https://www.richwhitehouse.com/ki/builds/BigInstinct_LinuxARM64_v${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_SECTION="emuelec/emulators"
+PKG_SHORTDESC="BigInstinct - Killer Instinct Arcade Emulator"
+PKG_TOOLCHAIN="manual"
+
+makeinstall_target() {
+  mkdir -p ${INSTALL}/usr/bin/biginstinct
+  cp -rv ${PKG_BUILD}/* ${INSTALL}/usr/bin/biginstinct/
+  chmod +x ${INSTALL}/usr/bin/biginstinct/biginstinct
+
+  cp -f ${PKG_DIR}/scripts/biginstinctstart.sh ${INSTALL}/usr/bin/biginstinctstart.sh
+  chmod +x ${INSTALL}/usr/bin/biginstinctstart.sh
+}

--- a/packages/sx05re/emulators/biginstinct/scripts/biginstinctstart.sh
+++ b/packages/sx05re/emulators/biginstinct/scripts/biginstinctstart.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Create libOpenGL.so.0 symlink in /tmp (filesystem is read-only)
+if [ ! -f /tmp/libOpenGL.so.0 ]; then
+  ln -sf /usr/lib/libGL.so.1 /tmp/libOpenGL.so.0
+fi
+
+# Add /tmp first so libOpenGL.so.0 symlink is found before other paths
+export LD_LIBRARY_PATH=/tmp:/usr/lib:/emuelec/lib:$LD_LIBRARY_PATH
+# Fix GL rendering issues on Mali GPU
+export LIBGL_NOTEST=1
+# Change to biginstinct directory
+cd /usr/bin/biginstinct
+# Launch biginstinct with all arguments
+./biginstinct "$@"

--- a/packages/sx05re/emulators/bigpemu/package.mk
+++ b/packages/sx05re/emulators/bigpemu/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2024-present EmuELEC Team (https://github.com/EmuELEC/EmuELEC)
 
 PKG_NAME="bigpemu"
-PKG_VERSION="121"
-PKG_SHA256="ac524e91fa6e90d9256d247d410279315fff9b61b6317c5f23172225139cceb1"
+PKG_VERSION="122"
+PKG_SHA256="afacd7254baa5d2858146651e1e2b7f7cc7beb7f0ea65cdc62a87c296170f646"
 PKG_ARCH="aarch64"
 PKG_LICENSE="Proprietary"
 PKG_SITE="https://www.richwhitehouse.com/jaguar"


### PR DESCRIPTION
Information about BigInstinct: https://richwhitehouse.com/ki/index.php

- added package.mk for BigInstinct

- added wrapper/start script biginstinctstart.sh

- updated necessary files (package.mk of emuelec, es_features.cfg, es_systems.json)

- modified emuelecRunEmu.sh with .bighard file-type override so that it does not matter where the two .bighard files have been placed (arcade, mame, fbn), biginstinctstart.sh is automatically being executed

------------------------------------------------------------------------------------------------------------------------------------------

- BONUS: updated BigPemu-emulator from version 1.21 to version 1.22 (updated package.mk)