### PR TITLE
Added amiarcadia libretro core, an Emulator for Emerson Arcadia 2001, Interton VC 4000 and Elektor TV Games Computer

### DIFF
--- a/distributions/EmuELEC/options
+++ b/distributions/EmuELEC/options
@@ -274,6 +274,7 @@
 LIBRETRO_CORES="2048 \
 81 \
 a5200 \
+amiarcadia \
 arduous \
 atari800 \
 b2 \

--- a/packages/sx05re/emuelec-emulationstation/config/es_features.cfg
+++ b/packages/sx05re/emuelec-emulationstation/config/es_features.cfg
@@ -4,6 +4,7 @@
     <cores>
       <core name="2048" features="netplay, rewind, autosave" />
       <core name="81" features="netplay, rewind, autosave" />
+	  <core name="amiacardia" features="netplay, rewind, autosave" />
 	  <core name="arduous" features="netplay, rewind, autosave" />
       <core name="atari800" features="netplay, rewind, autosave" />
       <core name="b2" features="netplay, rewind, autosave" />

--- a/packages/sx05re/emuelec-emulationstation/config/es_systems.json
+++ b/packages/sx05re/emuelec-emulationstation/config/es_systems.json
@@ -4543,6 +4543,7 @@
       "extensions": [
         ".cmd",
 		".zip",
+		".bin",
 		".7z"
       ],
       "emulators": [
@@ -4550,8 +4551,40 @@
           "name": "libretro",
           "cores": [
             {
-              "name": "mame",
+              "name": "amiarcadia",
               "default": true
+            },
+			{
+              "name": "mame"
+            }
+          ]
+        }
+      ]
+    },
+	{
+      "name": "tvgc",
+      "fullname": "Elektor TV Games Computer",
+      "manufacturer": "Elektor",
+      "release": "1979",
+      "hardware": "computer",
+      "path": "/storage/roms/tvgc",
+      "platform": "tvgc",
+      "theme": "tvgc",
+      "command": "default",
+      "extensions": [
+        ".tvc",
+		".zip"
+      ],
+      "emulators": [
+        {
+          "name": "libretro",
+          "cores": [
+            {
+              "name": "amiarcadia",
+              "default": true
+            },
+			{
+              "name": "mame"
             }
           ]
         }
@@ -4833,8 +4866,11 @@
           "name": "libretro",
           "cores": [
             {
-              "name": "mame",
+              "name": "amiarcadia",
               "default": true
+            },
+			{
+              "name": "mame"
             }
           ]
         }

--- a/packages/sx05re/libretro/amiarcadia/package.mk
+++ b/packages/sx05re/libretro/amiarcadia/package.mk
@@ -1,0 +1,23 @@
+PKG_NAME="amiarcadia"
+PKG_VERSION="34af1c9eb71c7ef58e7719e67d77881a99874c36"
+PKG_REV="1"
+PKG_ARCH="aarch64"
+PKG_LICENSE="Non-commercial"
+PKG_SITE="https://github.com/warmenhoven/amiarcadia"
+PKG_URL="$PKG_SITE.git"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="Libretro core for Signetics 2650 CPU-based systems (Arcadia 2001, Interton VC 4000, Elektor TV Games, Zaccaria, Malzak)."
+PKG_TOOLCHAIN="make"
+GET_HANDLER_SUPPORT="git"
+
+make_target() {
+  make platform=unix \
+    CC="$CC" \
+    CXX="$CXX" \
+    AR="$AR"
+}
+
+makeinstall_target() {
+  mkdir -p $INSTALL/usr/lib/libretro
+  cp amiarcadia_libretro.so $INSTALL/usr/lib/libretro/
+}


### PR DESCRIPTION
- added package.mk for libretro core "amicardia_libretro.so"

- updated options, es_features.cfg and es_systems.json