### PR TITLE
Added "Memu", a standalone Memotech MTX 512 emulator

### DIFF
--- a/packages/sx05re/emuelec-emulationstation/config/es_features.cfg
+++ b/packages/sx05re/emuelec-emulationstation/config/es_features.cfg
@@ -141,4 +141,5 @@
   <emulator name="eka2l1" features="nativevideo" />
   <emulator name="bigpemu" features="nativevideo" />
   <emulator name="biginstinct" features="nativevideo" />
+  <emulator name="memu" features="nativevideo" />
 </features>

--- a/packages/sx05re/emuelec-emulationstation/config/es_systems.json
+++ b/packages/sx05re/emuelec-emulationstation/config/es_systems.json
@@ -5389,7 +5389,7 @@
       ]
     },
 	{
-	  "name": "memu",
+	  "name": "mtx512",
       "fullname": "Memotech MTX 512",
       "manufacturer": "Memotech",
       "release": "1984",

--- a/packages/sx05re/emuelec-emulationstation/config/es_systems.json
+++ b/packages/sx05re/emuelec-emulationstation/config/es_systems.json
@@ -4619,7 +4619,7 @@
     },
 	{
       "name": "archimedes",
-      "fullname": "Archimede",
+      "fullname": "Archimedes",
       "manufacturer": "Acorn Computers",
       "release": "1987",
       "hardware": "computer",

--- a/packages/sx05re/emuelec-emulationstation/config/es_systems.json
+++ b/packages/sx05re/emuelec-emulationstation/config/es_systems.json
@@ -5389,6 +5389,41 @@
       ]
     },
 	{
+	  "name": "memu",
+      "fullname": "Memotech MTX 512",
+      "manufacturer": "Memotech",
+      "release": "1984",
+      "hardware": "computer",
+      "path": "/storage/roms/mtx512",
+      "platform": "mtx512",
+      "theme": "mtx512",
+      "command": "default",
+      "extensions": [
+        ".cmd",
+		".zip",
+        ".mtx"
+					],
+      "emulators": [
+        {
+          "name": "memu",
+          "cores": [
+            {
+              "name": "memu",
+              "default": true
+            }
+          ]
+        },
+        {
+          "name": "libretro",
+          "cores": [
+            {
+              "name": "mame"
+            }
+          ]
+        }
+      ]
+    },
+	{
 	"name": "x16",
 	"fullname": "Commander X16",
 	"manufacturer": "X16Community",

--- a/packages/sx05re/emuelec/bin/emuelecRunEmu.sh
+++ b/packages/sx05re/emuelec/bin/emuelecRunEmu.sh
@@ -386,6 +386,12 @@ case ${PLATFORM} in
             RUNTHIS='${TBASH} oricutronstart.sh "${ROMNAME}"'
         fi
 		;;	
+		"mtx512")
+        if [ "${EMU}" = "memu" ]; then
+            set_kill_keys "memu"
+            RUNTHIS='${TBASH} memustart.sh "${ROMNAME}"'
+        fi
+		;;	
         "dragon32"|"dragon64")
 			if [ "${EMU}" = "xroar" ]; then
 			set_kill_keys "xroar.aarch64"

--- a/packages/sx05re/emuelec/package.mk
+++ b/packages/sx05re/emuelec/package.mk
@@ -11,7 +11,7 @@ PKG_LONGDESC="EmuELEC Meta Package"
 PKG_TOOLCHAIN="manual"
 
 PKG_EXPERIMENTAL="nestopiaCV quasi88 xmil np2kai hypseus-singe yabasanshiroSA_1_11 yabasanshiroSA_1_5 fbneoSA same_cdi ikemen-go" 
-PKG_EMUS="${LIBRETRO_CORES} desmume melonds advancemame PPSSPPSDL amiberry amiberry-lite hatarisa openbor dosbox-staging mupen64plus-nx mupen64plus-nx-alt scummvmsa stellasa solarus dosbox-pure pcsx_rearmed ecwolf potator freej2me duckstation flycastsa fmsx-libretro jzintv mupen64plussa xroar x16 simcoupe ti99sim oricutron eka2l1 bigpemu biginstinct"
+PKG_EMUS="${LIBRETRO_CORES} desmume melonds advancemame PPSSPPSDL amiberry amiberry-lite hatarisa openbor dosbox-staging mupen64plus-nx mupen64plus-nx-alt scummvmsa stellasa solarus dosbox-pure pcsx_rearmed ecwolf potator freej2me duckstation flycastsa fmsx-libretro jzintv mupen64plussa xroar x16 simcoupe ti99sim oricutron eka2l1 bigpemu biginstinct memu"
 PKG_DEPENDS_TARGET+=" emuelec-tools ${PKG_EMUS} ${PKG_EXPERIMENTAL}"
 
 

--- a/packages/sx05re/emulators/memu/config/default.autotype
+++ b/packages/sx05re/emulators/memu/config/default.autotype
@@ -1,0 +1,1 @@
+<AutoShift><Wait150>load ""<RET>

--- a/packages/sx05re/emulators/memu/config/memu.gptk
+++ b/packages/sx05re/emulators/memu/config/memu.gptk
@@ -1,0 +1,56 @@
+# MEMU gptokeyb configuration (Memotech MTX).
+#
+# I N S T R U C T I O N S :
+#
+# If you have a game with special keys (for example Q for UP, A for DOWN etc.), change the mapping table beneath accordingly.
+#
+# Then SAVE that modified file under the game's name. For Example: Kilopede.gptk
+#
+# The correct filepath for the game-gptk file is: /storage/.config/emuelec/configs/memu/gptk
+#
+# For example: /storage/.config/emuelec/configs/memu/gptk/Kilopede.gptk
+#
+# MEMU will automatically load the respective gptk file when starting the game.
+# If no gptk file is found, the emulator will always use "memu.gptk" in /storage/.config/emuelec/configs/memu/gptk
+#
+#-----------------------------------------------------------------------------------------------------------------------
+#
+# Controller buttons -> keyboard keys 
+# HOME key is the FIRE button
+
+back  = space
+start = enter
+a = home
+b = 0
+x = 1
+y = 2
+
+# Shoulders/triggers/sticks -> keyboard keys
+
+l1 = z
+l2 = n
+l3 = m
+r1 = q
+r2 = a
+r3 = p
+
+# D-pad -> cursor keys
+
+up = up
+down = down
+left = left
+right = right
+
+# Left analog as alternative to D-pad
+
+left_analog_up = up
+left_analog_down = down
+left_analog_left = left
+left_analog_right = right
+
+# Right analog
+
+right_analog_up = up
+right_analog_down = down
+right_analog_left = left
+right_analog_right = right

--- a/packages/sx05re/emulators/memu/package.mk
+++ b/packages/sx05re/emulators/memu/package.mk
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+PKG_NAME="memu"
+PKG_VERSION="58a4281bc63d194c4f2df36ee83b14d8496b61f9"
+PKG_SHA256="296375dcad99fc000924e4a0c6b5f94db3fbd97b2690a1e61f81d71519c6d954"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/Memotech-Bill/MEMU"
+PKG_URL="https://github.com/Memotech-Bill/MEMU/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain alsa-lib"
+PKG_LONGDESC="Memotech MTX emulator"
+PKG_TOOLCHAIN="cmake"
+PKG_CMAKE_OPTS_TARGET="
+  -DTARGET=FBuf
+  -DCMAKE_BUILD_TYPE=Release
+"
+
+pre_configure_target() {
+  cat > /tmp/patch_memu.py << 'PYEOF'
+import sys
+kbd2_path = sys.argv[1]
+t = open(kbd2_path).read()
+# Add '"' (0x22 = Shift+2) to keyinfo table between ' '(0x20) and '#'(0x23)
+new_entry = '    {\'"\',' + "               {NKEY,0x11,NKEY,0x11,NKEY,0x11,NKEY,0x11},NKEY,NKEY}, // 0x22 Shift+2\n"
+t = t.replace("    {'#',", new_entry + "    {'#',", 1)
+open(kbd2_path, "w").write(t)
+PYEOF
+
+  # Enable AUTOTYPE in FBuf CMake build
+  sed -i 's/-DHAVE_NFX/-DHAVE_AUTOTYPE\n    -DHAVE_NFX/' \
+    ${PKG_BUILD}/CMakeLists.txt
+
+  # Add '"' character support for autotype
+  python3 /tmp/patch_memu.py "${PKG_BUILD}/src/memu/kbd2.c"
+}
+
+makeinstall_target() {
+  mkdir -p ${INSTALL}/usr/bin
+  cp -a ${PKG_BUILD}/run_time/memu-fb ${INSTALL}/usr/bin/memu
+  cp ${PKG_DIR}/scripts/memustart.sh ${INSTALL}/usr/bin/memustart.sh
+  chmod +x ${INSTALL}/usr/bin/memustart.sh
+
+  mkdir -p ${INSTALL}/usr/config/emuelec/configs/memu/gptk
+  mkdir -p ${INSTALL}/usr/config/emuelec/configs/memu/autotype
+  cp ${PKG_DIR}/config/memu.gptk \
+    ${INSTALL}/usr/config/emuelec/configs/memu/gptk/memu.gptk
+  cp ${PKG_DIR}/config/default.autotype \
+    ${INSTALL}/usr/config/emuelec/configs/memu/autotype/default.autotype
+
+  # MEMU runtime files
+  cp -a ${PKG_BUILD}/run_time/memu.cfg \
+        ${PKG_BUILD}/run_time/memu0.cfg \
+        ${PKG_BUILD}/run_time/alt_keypad.kbd \
+    ${INSTALL}/usr/config/emuelec/configs/memu/
+  cp -a ${PKG_BUILD}/run_time/roms \
+        ${PKG_BUILD}/run_time/disks \
+        ${PKG_BUILD}/run_time/tapes \
+    ${INSTALL}/usr/config/emuelec/configs/memu/
+}

--- a/packages/sx05re/emulators/memu/scripts/memustart.sh
+++ b/packages/sx05re/emulators/memu/scripts/memustart.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2024-present worstcase_scenario (https://github.com/worstcase-scenario)
+. /etc/profile
+
+ROM="$1"
+ROMNAME="${ROM##*/}"
+ROMBASE="${ROMNAME%.*}"
+EXT="${ROMNAME##*.}"
+EXT="${EXT,,}"
+
+CONFIGDIR="/storage/.config/emuelec/configs/memu"
+SYSCONFIGDIR="/usr/config/emuelec/configs/memu"
+
+mkdir -p "${CONFIGDIR}/gptk"
+mkdir -p "${CONFIGDIR}/autotype"
+
+[ ! -f "${CONFIGDIR}/gptk/memu.gptk" ] && \
+    cp "${SYSCONFIGDIR}/gptk/memu.gptk" "${CONFIGDIR}/gptk/memu.gptk"
+
+[ ! -f "${CONFIGDIR}/autotype/default.autotype" ] && \
+    cp "${SYSCONFIGDIR}/autotype/default.autotype" \
+       "${CONFIGDIR}/autotype/default.autotype"
+
+killall -9 gptokeyb 2>/dev/null
+
+GPTK_CONFIG="${CONFIGDIR}/gptk/memu.gptk"
+[ -f "${CONFIGDIR}/gptk/${ROMBASE}.gptk" ] && \
+    GPTK_CONFIG="${CONFIGDIR}/gptk/${ROMBASE}.gptk"
+
+gptokeyb 1 memu -c "$GPTK_CONFIG" &
+sleep 1
+
+echo 1 > /sys/class/graphics/fb0/osd_clear 2>/dev/null
+fbfix 0
+
+cd "${CONFIGDIR}"
+
+case "${EXT}" in
+  com)
+    MEMU_EXTRA="-cpm -iobyte 0x80"
+    ;;
+  mtx)
+    # Game-specific autotype: /storage/.config/emuelec/configs/memu/autotype/<ROMBASE>.autotype
+    # Default: /storage/.config/emuelec/configs/memu/autotype/default.autotype
+    AUTOTYPE="${CONFIGDIR}/autotype/default.autotype"
+    [ -f "${CONFIGDIR}/autotype/${ROMBASE}.autotype" ] && \
+        AUTOTYPE="${CONFIGDIR}/autotype/${ROMBASE}.autotype"
+    MEMU_EXTRA="-kbd-type-file ${AUTOTYPE}"
+    ;;
+  *)
+    MEMU_EXTRA=""
+    ;;
+esac
+
+/usr/bin/memu -vid-win -snd-portaudio ${MEMU_EXTRA} "${ROM}" </dev/tty1
+
+killall -9 gptokeyb 2>/dev/null


### PR DESCRIPTION
- Added Memu standalone emulator with implemented patch to add missing "-kbd-type" feature

- Added memustart.sh launcher script

- Added global memu.gptk file

- Added default.autotype (file for parsing commands like "Load" for games etc.)

- Updated emuelecrunEmu.sh, es_systems.json, es_features.cfg and package.mk for emuelec