### PR TITLE
Added "Gp32emu" libretro core, an emulator for the Game Park GP 32

### DIFF
--- a/distributions/EmuELEC/options
+++ b/distributions/EmuELEC/options
@@ -318,6 +318,7 @@ genesis_plus_gx_cart_special \
 genesis-plus-gx-wide \
 geolith \
 gme \
+gp32emu \
 gpsp \
 gw-libretro \
 handy \

--- a/packages/sx05re/emuelec-emulationstation/config/es_features.cfg
+++ b/packages/sx05re/emuelec-emulationstation/config/es_features.cfg
@@ -36,6 +36,7 @@
       <core name="genesis_plus_gx_wide" features="netplay, rewind, autosave, cheevos" />
       <core name="gme" features="netplay, rewind, autosave" />
       <core name="gpsp" features="netplay, rewind, autosave, cheevos" />
+	  <core name="gp32emu" features="netplay, rewind, autosave" />
       <core name="gw" features="netplay, rewind, autosave" />
       <core name="handy" features="netplay, rewind, autosave, cheevos, vertical" />
       <core name="hatari" features="netplay, rewind, autosave" />

--- a/packages/sx05re/emuelec-emulationstation/config/es_systems.json
+++ b/packages/sx05re/emuelec-emulationstation/config/es_systems.json
@@ -5623,6 +5623,38 @@
 		}
 	]
 	},
+		{
+	"name": "gp32",
+	"fullname": "GP 32",
+	"manufacturer": "Game Park",
+	"release": "2005",
+	"hardware": "portable",
+	"path": "/storage/roms/gp32",
+	"platform": "gp32",
+	"theme": "gp32",
+	"command": "default",
+	"extensions": [
+    ".smc",
+	".cmd",
+	".fxe",
+	".fpk",
+	".zip"
+	],
+	"emulators": [
+    {
+      "name": "libretro",
+      "cores": [
+			{
+          "name": "lowresnx",
+          "default": true
+			},
+			{
+          "name": "mame"
+            }
+		]
+		}
+	]
+	},
     {
       "name": "bk",
       "fullname": "Electronika",

--- a/packages/sx05re/libretro/gp32emu/package.mk
+++ b/packages/sx05re/libretro/gp32emu/package.mk
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2024-present EmuELEC (https://github.com/EmuELEC/EmuELEC)
+
+PKG_NAME="gp32emu"
+PKG_VERSION="9ca3a72fac79eb57dd16ec21f3756e243e4a579d"
+PKG_ARCH="any"
+PKG_LICENSE="LGPL"
+PKG_SITE="https://github.com/gameblabla/gp32emu"
+PKG_URL="${PKG_SITE}/archive/refs/heads/main.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_SHORTDESC="GP32 libretro core"
+PKG_TOOLCHAIN="make"
+
+pre_configure_target() {
+  cd ${PKG_BUILD}
+}
+
+make_target() {
+  make -f Makefile.libretro \
+    CC="${CC}" \
+    AR="${AR}" \
+    CFLAGS="${CFLAGS} -std=c11 -fPIC" \
+    GP32EMU_ENABLE_THREADS=0 \
+    clean all
+}
+
+makeinstall_target() {
+  mkdir -p ${INSTALL}/usr/lib/libretro
+  cp gp32emu_libretro.so ${INSTALL}/usr/lib/libretro/
+
+  mkdir -p ${INSTALL}/usr/share/libretro/info
+  cp ${PKG_BUILD}/gp32emu_libretro.info \
+     ${INSTALL}/usr/share/libretro/info/
+}


### PR DESCRIPTION
- added package.mk for libretro core "gp32emu_libretro.so"

- updated options, es_features.cfg and es_systems.json