### PR TITLE
Updated hypseus to version 2.12.1

### DIFF
--- a/packages/sx05re/emuelec/bin/hypseus.start.sh
+++ b/packages/sx05re/emuelec/bin/hypseus.start.sh
@@ -3,13 +3,16 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2021-present Shanti Gilbert (https://github.com/shantigilbert)
 
-dir="${1}"
+dir="${1%/}"
 name=${dir##*/}
 name=${name%.*}
 config="/storage/.config/emuelec/configs/hypseus"
 configfile="${config}/hypinput.ini"
 
-export AUDIODEV=hw:0,0
+# hypseus core (SDL_OpenAudioDevice) and Singe (Mix_OpenAudio) both open
+# the audio device since 2.11.4 - raw hw:0,0 only allows one client,
+# so use dmix for software mixing.
+export AUDIODEV="plug:dmix"
 
 if [[ ! -f "${config}/ee_updated" ]]; then
     cp "/usr/config/emuelec/configs/hypseus/hypinput_gamepad.ini" "${configfile}"
@@ -25,8 +28,34 @@ sed -i 's|AXIS_TRIGGER_RIGHT|BUTTON_X AXIS_TRIGGER_RIGHT|' ${configfile}
 
 cd "${config}"
 
-if [[ -f "${dir}/${name}.singe" ]]; then
-    hypseus singe vldp -gamepad -manymouse -framefile "${dir}/${name}.txt" -script "${dir}/${name}.singe" -fullscreen -useoverlaysb 2 ${params}
-else
-    hypseus "${name}" vldp -gamepad -manymouse -framefile "${dir}/${name}.txt" -fullscreen -useoverlaysb 2 ${params}
+# -useoverlaysb is only valid for lair/ace/tq since hypseus 2.12,
+# any other game type will hard-fail on this argument
+sboverlay=""
+case "${name}" in
+    lair|ace|tq)
+        sboverlay="-useoverlaysb 2"
+        ;;
+esac
+
+# Load bezel from the game dir if present (both naming conventions)
+bezel=""
+if [[ -f "${dir}/bezel_${name}.png" ]]; then
+    bezel="-bezeldir ${dir} -bezel bezel_${name}.png"
+elif [[ -f "${dir}/${name}.png" ]]; then
+    bezel="-bezeldir ${dir} -bezel ${name}.png"
 fi
+
+if [[ -f "${dir}/${name}.zip" ]]; then
+    hypseus singe vldp -gamepad -manymouse -framefile "${dir}/${name}.txt" -zlua "${dir}/${name}.zip" -fullscreen ${bezel} ${params}
+elif [[ -f "${dir}/${name}.singe" ]]; then
+    hypseus singe vldp -gamepad -manymouse -framefile "${dir}/${name}.txt" -script "${dir}/${name}.singe" -fullscreen ${bezel} ${params}
+else
+    hypseus "${name}" vldp -gamepad -manymouse -framefile "${dir}/${name}.txt" -fullscreen ${sboverlay} ${params}
+fi
+
+ret=$?
+
+if [[ ${ret} -eq 143 ]]; then
+    exit 0
+fi
+exit ${ret}

--- a/packages/sx05re/emulators/hypseus-singe/package.mk
+++ b/packages/sx05re/emulators/hypseus-singe/package.mk
@@ -1,19 +1,16 @@
-# SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2021-present Shanti Gilbert (https://github.com/shantigilbert)
-
 PKG_NAME="hypseus-singe"
-PKG_VERSION="8397498bccd5dd8afc55b2200d533d66e17be56f"
+PKG_VERSION="4cfd20d834ee6cf42c1c347ffd2627d87aaf8e2f"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL3"
 PKG_SITE="https://github.com/DirtBagXon/hypseus-singe"
 PKG_URL="${PKG_SITE}.git"
-PKG_DEPENDS_TARGET="toolchain SDL2 libvorbis SDL2_ttf SDL2_image"
+PKG_GIT_CLONE_BRANCH="sdl2"
+PKG_DEPENDS_TARGET="toolchain SDL2 libvorbis SDL2_ttf SDL2_image SDL2_mixer libmpeg2"
 PKG_LONGDESC="Hypseus is a fork of Daphne. A program that lets one play the original versions of many laserdisc arcade games on one's PC."
 PKG_TOOLCHAIN="cmake"
 GET_HANDLER_SUPPORT="git"
-
-PKG_CMAKE_OPTS_TARGET=" ./src"
+PKG_CMAKE_OPTS_TARGET="-DABSTRACT_SINGE=OFF ./src"
 
 pre_configure_target() {
 mkdir -p ${INSTALL}/usr/config/emuelec/configs/hypseus
@@ -21,9 +18,15 @@ ln -fs /storage/roms/daphne/roms ${INSTALL}/usr/config/emuelec/configs/hypseus/r
 ln -fs /usr/share/daphne/sound ${INSTALL}/usr/config/emuelec/configs/hypseus/sound
 ln -fs /usr/share/daphne/fonts ${INSTALL}/usr/config/emuelec/configs/hypseus/fonts
 ln -fs /usr/share/daphne/pics ${INSTALL}/usr/config/emuelec/configs/hypseus/pics
+ln -fs /usr/share/daphne/midi ${INSTALL}/usr/config/emuelec/configs/hypseus/midi
 }
 
 post_makeinstall_target() {
+mkdir -p ${INSTALL}/usr/share/daphne
+cp -rf ${PKG_BUILD}/pics ${INSTALL}/usr/share/daphne/
+cp -rf ${PKG_BUILD}/sound ${INSTALL}/usr/share/daphne/
+cp -rf ${PKG_BUILD}/fonts ${INSTALL}/usr/share/daphne/
+cp -rf ${PKG_BUILD}/midi ${INSTALL}/usr/share/daphne/
 cp -rf ${PKG_BUILD}/doc/hypinput.ini ${INSTALL}/usr/config/emuelec/configs/hypseus/hypinput.ini
 cp -rf ${PKG_BUILD}/doc/hypinput_gamepad.ini ${INSTALL}/usr/config/emuelec/configs/hypseus/hypinput_gamepad.ini
 ln -fs /storage/.config/emuelec/configs/hypseus/hypinput.ini ${INSTALL}/usr/share/daphne/hypinput.ini

--- a/packages/sx05re/emulators/hypseus-singe/patches/hypseus-singe-001-buildfix.patch
+++ b/packages/sx05re/emulators/hypseus-singe/patches/hypseus-singe-001-buildfix.patch
@@ -1,13 +1,15 @@
---- a/src/CMakeLists.txt	2021-06-07 19:12:18.646828485 +0200
-+++ b/src/CMakeLists.txt	2021-06-07 19:13:56.113491528 +0200
-@@ -52,15 +52,13 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index abb2d21..766e35e 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -55,15 +55,13 @@ include(GNUInstallDirs)
  include(GetGitRevisionDescription)
  include(InstallRequiredSystemLibraries)
  include(FindPkgConfig)
 -include(ExternalProject)
 -include(BuildLibMPEG2)
  
- use_cxx11( )
+ set (CMAKE_CXX_STANDARD 11)
  
  PKG_SEARCH_MODULE(SDL2 REQUIRED sdl2)
  PKG_SEARCH_MODULE(SDL2_TTF REQUIRED SDL2_ttf)
@@ -17,7 +19,7 @@
  
  message(STATUS "Target: ${CMAKE_SYSTEM_NAME} ${CMAKE_TARGET_ARCHITECTURES}")
  
-@@ -114,7 +112,6 @@
+@@ -117,7 +115,6 @@ add_subdirectory(timer)
  add_subdirectory(video)
  add_subdirectory(vldp)
  
@@ -25,47 +27,37 @@
  add_dependencies( ldp-out vldp )
  add_dependencies( game vldp )
  add_dependencies( sound vldp )
-@@ -162,3 +159,5 @@
+@@ -165,3 +162,5 @@ set(CPACK_PACKAGE_VERSION_MINOR "${VER_MINOR}")
  set(CPACK_PACKAGE_VERSION_PATCH "${VER_PATCH}")
  
  include(CPack)
-+install(TARGETS hypseus DESTINATION bin)
-+install(DIRECTORY ../pics ../fonts ../sound DESTINATION /usr/share/daphne)
-diff --git a/src/vldp/vldp.h b/src/vldp/vldp.h
-index a59c723..3c986dc 100644
---- a/src/vldp/vldp.h
-+++ b/src/vldp/vldp.h
-@@ -34,6 +34,8 @@ extern "C" {
- // Ubuntu Linux complains with plain <SDL.h>
- #include <SDL2/SDL.h> // only used for threading
- 
-+#include <mpeg2dec/mpeg2.h>
 +
- struct yuv_buf {
-     uint8_t *Y;     // Y channel
-     uint8_t *U;     // U channel
++install(TARGETS hypseus DESTINATION bin)
+diff --git a/src/vldp/vldp_internal.cpp b/src/vldp/vldp_internal.cpp
+index 16a74cb..1aae541 100644
+--- a/src/vldp/vldp_internal.cpp
++++ b/src/vldp/vldp_internal.cpp
+@@ -41,7 +41,9 @@
+ 
+ #include <inttypes.h>
+ 
++extern "C" {
+ #include <mpeg2.h>
++}
+ 
+ #ifdef VLDP_DEBUG
+ #define FRAMELOG "frame_report.txt"
 diff --git a/src/vldp/vldp_internal.h b/src/vldp/vldp_internal.h
-index cd046fe..67cea2d 100644
+index 88450e9..e3f2bc6 100644
 --- a/src/vldp/vldp_internal.h
 +++ b/src/vldp/vldp_internal.h
-@@ -27,7 +27,6 @@
+@@ -27,7 +27,9 @@
  
  #include "vldp.h" // for the VLDP_BOOL definition and SDL.h
  
--#include <mpeg2.h>
++extern "C" {
+ #include <mpeg2.h>
++}
  
  // this is which version of the .dat file format we are using
- #define DAT_VERSION 2
- 
---- a/src/manymouse/CMakeLists.txt
-+++ b/src/manymouse/CMakeLists.txt
-@@ -1,7 +1,8 @@
-+
-+
- set( LIB_SOURCES
-     manymouse.c linux_evdev.c macosx_hidmanager.c
-     macosx_hidutilities.c windows_wminput.c
--    x11_xinput2.c
- )
- 
- set( LIB_HEADERS
+ #define DAT_VERSION 3


### PR DESCRIPTION
- Updated standalone emulator hypseus to version 2.12.1 (package.mk)

- modified patch file "hypseus-singe-001-buildfix.patch"

- updated hypseus.start.sh script, removed old overlay flag and added an additional check (as "-useoverlaysb" is only valid for lair/ace/tq since hypseus 2.12) and also changed export AUDIODEV=hw:0,0 to export AUDIODEV="plug:dmix" (as hypseus core (SDL_OpenAudioDevice) and Singe (Mix_OpenAudio) both open the audio device since 2.11.4 and "raw hw:0,0" only allows one client)